### PR TITLE
Enable CTest.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.6)
 project(cpisynclib)
 set(CMAKE_CXX_STANDARD 11)
 
+include(CTest)
+
 # some flags
 set(CMAKE_CXX_FLAGS "-DDEFAULT_LOGLEVEL=TEST")
 


### PR DESCRIPTION
The add_test command is being used to register tests with ctest. By
including the CTest module in the build dependencies, the ctest
command and the 'test' build target can run the registered tests.
Current behavior can be restored by adding -DBUILD_TESTING=OFF to the
cmake command.