### PR TITLE
Updates from the comments on the last pull request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,10 +59,10 @@ link_directories(/usr/local/lib)
 add_library(cpisynclib ${SOURCE_FILES} ${SRC_DIR}/main.cpp)
 
 # Add the TryMe executable
-add_executable(cpisync ${SRC_DIR}/main.cpp)
-add_executable(tryMe ${SRC_DIR}/TryMe.cpp)
-target_link_libraries(cpisync cpisynclib ntl)
-target_link_libraries(tryMe cpisynclib ntl)
+#add_executable(cpisync ${SRC_DIR}/main.cpp)
+#add_executable(tryMe ${SRC_DIR}/TryMe.cpp)
+#target_link_libraries(cpisync cpisynclib ntl)
+#target_link_libraries(tryMe cpisynclib ntl)
 
 # Add the TryMe executable
 add_executable(TryMe ${SRC_DIR}/TryMe.cpp)

--- a/tests/TestAuxiliary.h
+++ b/tests/TestAuxiliary.h
@@ -316,12 +316,102 @@ inline vector<GenSync> fileCombos() {
 }
 
 /**
- * Runs tests assuring that two GenSync objects successfully sync via two-way communication
+ * Runs client (child process) and server (parent process) returning a boolean for the success or failure of the sync
+ * @param GenSyncClient The GenSync object that plays the role of client in the sync.
+ * @param GenSyncServer The GenSync object that plays the role of server in the sync.
  * @param oneWay true iff the sync will be one way (only server is reconciled)
+ * @param probSync true iff the sync method being used is probabilistic (changes the conditions for success)
+ * @param syncParamTest true if you would like to know if the sync believes it succeeded regardless of the actual state
+ * of the sets (For parameter mismatch testing)
+ * @param SIMILAR Amount of elements common to both genSyncs
+ * @param CLIENT_MINUS_SERVER amt of elements unique to client
+ * @param SERVER_MINUS_CLIENT amt of elements unique to server
+ * @param reconciled The expected reconciled dataset
+ * @return True if the recon appears to be successful and false otherwise (if syncParamTest = true returns the
+ * result of both forkHandles anded together)
+ */inline bool syncTestForkHandle(GenSync& GenSyncClient, GenSync& GenSyncServer,bool oneWay, bool probSync,bool syncParamTest,
+								  const unsigned char SIMILAR,const unsigned char CLIENT_MINUS_SERVER,
+								  const unsigned char SERVER_MINUS_CLIENT, multiset<string> reconciled){
+	bool success_signal;
+	int chld_state;
+	int my_opt = 0;
+	pid_t pID = fork();
+	if (pID == 0) {
+		bool clientReconcileSuccess = true;
+		signal(SIGCHLD, SIG_IGN);
+		if (!oneWay) {
+			// reconcile client with server
+			forkHandleReport clientReport = forkHandle(GenSyncClient, GenSyncServer);
+
+
+			multiset<string> resClient;
+			for (auto dop : GenSyncClient.dumpElements()) {
+				resClient.insert(dop->print());
+			}
+
+			clientReconcileSuccess = clientReport.success;
+			//If syncParamTest only the result of the fork handle is relevant
+			if (!syncParamTest) {
+				if (probSync) {
+					// True iff the reconciled set contains at least one more element than it did before reconciliation
+					// and the elements added during reconciliation were elements that the client was lacking that the server had
+					clientReconcileSuccess &= resClient.size() > (SIMILAR + CLIENT_MINUS_SERVER) &&
+											  multisetDiff(reconciled, resClient).size() <
+											  (CLIENT_MINUS_SERVER + SERVER_MINUS_CLIENT);
+				}
+				else {
+					clientReconcileSuccess &= (resClient == reconciled);
+				}
+			}
+		}
+		exit(clientReconcileSuccess);
+	}
+	else if (pID < 0) {
+		Logger::error_and_quit("Fork error in sync test");
+	}
+	else {
+		// wait for child process to complete
+		waitpid(pID, &chld_state, my_opt);
+		//chld_state will be nonzero if clientReconcileSuccess is nonzero
+		success_signal = chld_state;
+		// reconcile server with client
+		forkHandleReport serverReport = forkHandle(GenSyncServer, GenSyncClient);
+		multiset<string> resServer;
+		for (auto dop : GenSyncServer.dumpElements()) {
+			resServer.insert(dop->print());
+		}
+		if(!syncParamTest){
+			if (probSync) {
+				// True iff the reconciled set contains at least one more element than it did before reconciliation
+				// and the elements added during reconciliation were elements that the server was lacking that the client had
+				bool serverReconcileSuccess = resServer.size() > (SIMILAR + SERVER_MINUS_CLIENT) &&
+											  multisetDiff(reconciled, resServer).size() < (CLIENT_MINUS_SERVER + SERVER_MINUS_CLIENT) && serverReport.success;
+
+				if (oneWay) return (serverReconcileSuccess);
+				else return (serverReconcileSuccess && success_signal);
+			} else {
+				if (oneWay) return (resServer == reconciled && serverReport.success);
+				else return ((success_signal) && (reconciled == resServer) && serverReport.success);
+			}
+		}
+		else{
+			return serverReport.success;
+		}
+	}
+}
+
+/**
+ * Runs tests assuring that two GenSync objects successfully sync via two-way communication
  * @param GenSyncServer Server GenSync
  * @param GenSyncClient Client GenSync
+ * @param oneWay true iff the sync will be one way (only server is reconciled)
+ * @param probSync true iff the sync method being used is probabilistic (changes the conditions for success)
+ * @param syncParamTest true if you would like to know if the sync believes it succeeded regardless of the actual state
+ * of the sets (For parameter mismatch testing)
+ * @return Returns true if the recon appears to be successful and false otherwise (if syncParamTest = true returns the
+ * result of both forkHandles anded together)
  */
-inline bool _syncTest(GenSync GenSyncServer, GenSync GenSyncClient, bool oneWay=false, bool probSync=false) {
+inline bool _syncTest(GenSync GenSyncServer, GenSync GenSyncClient, bool oneWay=false, bool probSync=false,bool syncParamTest=false) {
     for(int jj = 0; jj < NUM_TESTS; jj++) {
         // setup DataObjects
         const unsigned char SIMILAR = randByte(); // amt of elems common to both GenSyncs
@@ -330,8 +420,7 @@ inline bool _syncTest(GenSync GenSyncServer, GenSync GenSyncClient, bool oneWay=
 
         vector<DataObject *> objectsPtr;
 
-        for (unsigned long ii = 0; ii < SIMILAR + SERVER_MINUS_CLIENT + CLIENT_MINUS_SERVER -
-                                        1; ii++) {
+        for (unsigned long ii = 0; ii < SIMILAR + SERVER_MINUS_CLIENT + CLIENT_MINUS_SERVER - 1; ii++) {
             objectsPtr.push_back(new DataObject(randZZ()));
         }
         ZZ *last = new ZZ(randZZ()); // last datum represented by a ZZ so that the templated addElem can be tested
@@ -365,65 +454,9 @@ inline bool _syncTest(GenSync GenSyncServer, GenSync GenSyncClient, bool oneWay=
 			reconciled.insert(dop->print());
 		}
 
-        // create two processes to test successful reconciliation. the parent process tests the server; the child, the client.
-		bool success_signal;
-        int chld_state;
-        int my_opt = 0;
-        pid_t pID = fork();
-        if (pID == 0) {
-			bool clientReconcileSuccess = true;
-			signal(SIGCHLD, SIG_IGN);
-			if (!oneWay) {
-				// reconcile client with server
-				forkHandleReport clientReport = forkHandle(GenSyncClient, GenSyncServer);
-
-
-				multiset<string> resClient;
-				for (auto dop : GenSyncClient.dumpElements()) {
-					resClient.insert(dop->print());
-				}
-
-				clientReconcileSuccess = clientReport.success;
-
-				if (probSync) {
-					// True iff the reconciled set contains at least one more element than it did before reconciliation
-					// and the elements added during reconciliation were elements that the client was lacking that the server had
-					clientReconcileSuccess &= resClient.size() > (SIMILAR + CLIENT_MINUS_SERVER) &&
-							multisetDiff(reconciled, resClient).size() < (CLIENT_MINUS_SERVER + SERVER_MINUS_CLIENT);
-				} else {
-					clientReconcileSuccess &= (resClient == reconciled);
-				}
-			}
-            exit(clientReconcileSuccess);
-        }
-        else if (pID < 0) {
-        	Logger::error_and_quit("Fork error in sync test");
-        }
-        else {
-			// wait for child process to complete
-			waitpid(pID, &chld_state, my_opt);
-			//chld_state will be nonzero if clientReconcileSuccess is nonzero
-			success_signal = chld_state;
-			// reconcile server with client
-			forkHandleReport serverReport = forkHandle(GenSyncServer, GenSyncClient);
-			multiset<string> resServer;
-			for (auto dop : GenSyncServer.dumpElements()) {
-				resServer.insert(dop->print());
-			}
-
-			if (probSync) {
-				// True iff the reconciled set contains at least one more element than it did before reconciliation
-				// and the elements added during reconciliation were elements that the server was lacking that the client had
-				bool serverReconcileSuccess = resServer.size() > (SIMILAR + SERVER_MINUS_CLIENT) &&
-						multisetDiff(reconciled, resServer).size() < (CLIENT_MINUS_SERVER + SERVER_MINUS_CLIENT) && serverReport.success;
-
-				if (oneWay) return (serverReconcileSuccess);
-				else return (serverReconcileSuccess && success_signal);
-			} else {
-				if (oneWay) return (resServer == reconciled && serverReport.success);
-				else return ((success_signal) && (reconciled == resServer) && serverReport.success);
-			}
-		}
+		//Returns a boolean value for the success of the synchronization
+		return syncTestForkHandle(GenSyncClient,GenSyncServer,oneWay,probSync,syncParamTest,SIMILAR,CLIENT_MINUS_SERVER,
+				SERVER_MINUS_CLIENT,reconciled);
 	}
 }
 
@@ -463,6 +496,11 @@ inline bool syncTestProb(const GenSync &GenSyncClient, const GenSync &GenSyncSer
     return _syncTest(GenSyncClient, GenSyncServer, false, true);
 }
 
+/**
+ * Two way probabilistic synctest
+ * @port The port that the commSockets will make a connection on (8001)
+ * @host The host that the commSockets will use (localhost)
+ */
 inline bool socketSendReceiveTest(){
 	vector<string> sampleData;
 
@@ -480,16 +518,19 @@ inline bool socketSendReceiveTest(){
 		serverSocket.commListen();
 
 		//If any of the tests fail return false
-		for(int ii = 0; ii < TIMES; ii++)
-			if(!(serverSocket.commRecv(sampleData.at(ii).length()) == sampleData.at(ii))){
+		for(int ii = 0; ii < TIMES; ii++) {
+			if (!(serverSocket.commRecv(sampleData.at(ii).length()) == sampleData.at(ii))) {
 				serverSocket.commClose();
 				Logger::error_and_quit("Received message does not match sent message");
+				return false;
 			}
+		}
 
 		serverSocket.commClose();
 		exit(0);
 	} else if (pID < 0) {
 		Logger::error("Error forking in CommSocketTest");
+		return false;
 	} else {
 		Logger::gLog(Logger::COMM,"created a client socket process");
 		CommSocket clientSocket(port,host);

--- a/tests/TestAuxiliary.h
+++ b/tests/TestAuxiliary.h
@@ -497,7 +497,6 @@ inline bool syncTestProb(const GenSync &GenSyncClient, const GenSync &GenSyncSer
 }
 
 /**
- * Two way probabilistic synctest
  * @port The port that the commSockets will make a connection on (8001)
  * @host The host that the commSockets will use (localhost)
  */

--- a/tests/unit/CommSocketTest.h
+++ b/tests/unit/CommSocketTest.h
@@ -19,10 +19,14 @@ public:
     void tearDown() override;
 
 private:
-  	// Tests getName and getHost functions ensuring that constructor is working as intended
+	/**
+ 	* Tests getName and getHost functions ensuring that constructor is working as intended
+ 	*/
     void GetSocketInfo();
 
-	// Tests sending and receiving a string of characters through a socket
+	/**
+ 	* Tests sending and receiving a string of characters through a socket
+ 	*/
     void SocketSendAndReceiveTest();
 
 };

--- a/tests/unit/CommStringTest.h
+++ b/tests/unit/CommStringTest.h
@@ -28,13 +28,19 @@ public:
     void tearDown() override;
 
 private:
-    // Tests that CommString::getString() correctly returns the string passed at construction
+	/**
+ 	* Tests that CommString::getString() correctly returns the string passed at construction
+ 	*/
     void testGetString();
 
-    // Tests that CommString::getName() correctly returns "CommString"
+	/**
+ 	* Tests that CommString::getName() correctly returns "CommString"
+ 	*/
     void testGetName();
 
-    // Tests a full round of communication
+	/**
+ 	* Tests a full round of communication
+ 	*/
     void testComm();
 
 };

--- a/tests/unit/CommunicantTest.h
+++ b/tests/unit/CommunicantTest.h
@@ -47,52 +47,84 @@ private:
     const int UPPER_BOUND = 50; // Upper bound on the length of random strings
     const double DELTA = 0.00001; // error tolerance comparing doubles
 
-    // Tests argument-free construction.
+	/**
+ 	* Tests argument-free construction.
+ 	*/
     void testConstruct();
-    
-    // Tests bytes-communicated-counter getters and resetCommCounters.
+
+	/**
+ 	* Tests bytes-communicated-counter getters and resetCommCounters.
+ 	*/
     void testBytesAndResetCommCounters();
-    
-    // Tests establishMod functions, commSend for ZZ_p, and commRecv for ZZ_p.
+
+	/**
+ 	* Tests establishMod functions, commSend for ZZ_p, and commRecv for ZZ_p.
+ 	*/
     void testEstablishModAndCommZZ_p();
-    
-    // Tests commSend and Recv for ustring, passing the size of the ustring in bytes as an argument.
+
+	/**
+ 	* Tests commSend and Recv for ustring, passing the size of the ustring in bytes as an argument.
+ 	*/
     void testCommUstringBytes();
-    
-    // Tests commSend and Recv for string
+
+	/**
+ 	* Tests commSend and Recv for string
+ 	*/
     void testCommString();
-    
-    // Tests commSend and Recv for long int
+
+	/**
+ 	* Tests commSend and Recv for long int
+ 	*/
     void testCommLong();
-    
-    // Tests commSend and Recv for ustring without passing size as an argument
+
+	/**
+ 	* Tests commSend and Recv for ustring without passing size as an argument
+ 	*/
     void testCommUstringNoBytes();
-    
-    // Tests commSend and Recv for normal DataObject
+
+	/**
+ 	* Tests commSend and Recv for normal DataObject
+ 	*/
     void testCommDataObject();
-    
-    // Tests commSend and Recv for DataObject with priority
+
+	/**
+ 	* Tests commSend and Recv for DataObject with priority
+ 	*/
     void testCommDataObjectPriority();
-    
-    // Tests commSend and Recv for a list of DataObject
+
+	/**
+ 	* Tests commSend and Recv for a list of DataObject
+ 	*/
     void testCommDataObjectList();
-    
-    // Tests commSend and Recv for double
+
+	/**
+ 	* Tests commSend and Recv for double
+ 	*/
     void testCommDouble();
-    
-    // Tests commSend and Recv for byte
+
+	/**
+ 	* Tests commSend and Recv for byte
+ 	*/
     void testCommByte();
-    
-    // Tests commSend and Recv for int
+
+	/**
+ 	* Tests commSend and Recv for int
+ 	*/
     void testCommInt();
-    
-    // Tests commSend and Recv for vec_ZZ_p. Requires establishModSend and Recv
+
+	/**
+ 	* Tests commSend and Recv for vec_ZZ_p. Requires establishModSend and Recv
+ 	*/
     void testCommVec_ZZ_p();
-    
-    // Tests commSend and Recv for ZZ, passing the size of the ZZ as an argument
+
+	/**
+ 	* Tests commSend and Recv for ZZ, passing the size of the ZZ as an argument
+ 	*/
     void testCommZZ();
-    
-    // Tests commSend and Recv for ZZ without passing any arguments
+
+	/**
+ 	* Tests commSend and Recv for ZZ without passing any arguments
+ 	*/
     void testCommZZNoArgs();
 
     

--- a/tests/unit/DataObjectTest.h
+++ b/tests/unit/DataObjectTest.h
@@ -14,25 +14,18 @@
 class DataObjectTest : public CPPUNIT_NS::TestFixture {
     CPPUNIT_TEST_SUITE(DataObjectTest);
 
-    // Tests constructing a DataObject with a ZZ and DataObject::toZZ
     CPPUNIT_TEST(testToZZAndInitZZ);
 
-    // Tests DataObject::to_string and constructing a DataObject with a string
     CPPUNIT_TEST(testToStringAndInitString);
 
-    // Tests DataObject::to_string and constructing an empty DataObject
     CPPUNIT_TEST(testToStringAndInitEmpty);
 
-    // Tests DataObject::to_char_array
     CPPUNIT_TEST(testToCharArray);
 
-    // Tests DataObject::print
     CPPUNIT_TEST(testPrint);
 
-    // Tests DataObject::operator<<
     CPPUNIT_TEST(testStreamInsertion);
 
-    // Tests DataObject::operator<
     CPPUNIT_TEST(testLessThan);
 
     CPPUNIT_TEST_SUITE_END();
@@ -49,12 +42,39 @@ public:
     void tearDown() override;
 
 private:
+	/**
+ 	* Tests constructing a DataObject with a ZZ and DataObject::toZZ
+ 	*/
     void testToZZAndInitZZ();
+
+	/**
+ 	* Tests DataObject::to_string and constructing a DataObject with a string
+ 	*/
     void testToStringAndInitString();
+
+	/**
+ 	* Tests DataObject::to_string and constructing an empty DataObject
+ 	*/
     void testToStringAndInitEmpty();
+
+	/**
+ 	* Tests DataObject::to_char_array
+ 	*/
     void testToCharArray();
+
+	/**
+ 	* Tests DataObject::print
+ 	*/
     void testPrint();
+
+	/**
+ 	* Tests DataObject::operator<<
+ 	*/
     void testStreamInsertion();
+
+	/**
+ 	* Tests DataObject::operator<
+ 	*/
     void testLessThan();
 };
 

--- a/tests/unit/DataPriorityObjectTest.h
+++ b/tests/unit/DataPriorityObjectTest.h
@@ -12,28 +12,17 @@
 #include <cppunit/extensions/HelperMacros.h>
 
 class DataPriorityObjectTest : public CPPUNIT_NS::TestFixture {
-CPPUNIT_TEST_SUITE(DataPriorityObjectTest);
 
-        /**
-         * Tests DataObject::to_priority_string, initializing a DataObject with a generic type that can be converted into a
-         * string, and DataObject::setPriority.
-         */
+		CPPUNIT_TEST_SUITE(DataPriorityObjectTest);
+
         CPPUNIT_TEST(testToPriorityStringAndInitStringableAndSetPriority);
+        CPPUNIT_TEST(testPriority);
+        CPPUNIT_TEST(testTimeStamp);
 
-        // Tests DataObject::getPriority
-
-            // Tests DataObject::getPriority
-            CPPUNIT_TEST(testPriority);
-
-            // Tests DataObject::setTimeStamp and DataObject::getTimeStamp
-            CPPUNIT_TEST(testTimeStamp);
-
-    CPPUNIT_TEST_SUITE_END();
+    	CPPUNIT_TEST_SUITE_END();
 
 public:
     const int TIMES = 50; // times to run a test
-    const int LOWER = 0;
-    const int UPPER = 50;
 
     DataPriorityObjectTest() = default;
 
@@ -42,8 +31,18 @@ public:
     void tearDown() override {}
 
 private:
+	/**
+	 * Tests DataObject::to_priority_string, initializing a DataObject with a generic type that can be converted into a
+	 * string, and DataObject::setPriority.
+	 */
     void testToPriorityStringAndInitStringableAndSetPriority();
+	/**
+ 	* Tests DataObject::getPriority
+ 	*/
     void testPriority();
+	/**
+ 	* Tests DataObject::setTimeStamp and DataObject::getTimeStamp
+ 	*/
     void testTimeStamp();
 
     const int SEED = 617;

--- a/tests/unit/FullSyncTest.h
+++ b/tests/unit/FullSyncTest.h
@@ -27,14 +27,21 @@ public:
     void setUp() override;
     void tearDown() override;
 
-    // Test reconciliation
+	/**
+ 	* Test reconciliation
+ 	*/
     void justSyncTest();
 
-    // Test adding and deleting elements
+	/**
+ 	* Test adding and deleting elements
+ 	*/
     void testAddDelElem();
 
-    // Test that printElem() and getName() return some nonempty string
+	/**
+ 	* Test that printElem() and getName() return some nonempty string
+ 	*/
     void testGetStrings();
+
 };
 
 #endif /* FULLSYNCTEST_H */

--- a/tests/unit/IBLTSyncTest.cpp
+++ b/tests/unit/IBLTSyncTest.cpp
@@ -76,3 +76,26 @@ void IBLTSyncTest::testGetStrings() {
 
     CPPUNIT_ASSERT(!ibltSync.getName().empty());
 }
+
+void IBLTSyncTest::testIBLTParamMismatch(){
+	const int BITS = sizeof(randZZ());
+	const int EXP_ELEM = UCHAR_MAX * 2;
+	const int EXP_ELEM_OTHER = EXP_ELEM + 100;
+
+	GenSync GenSyncServer = GenSync::Builder().
+			setProtocol(GenSync::SyncProtocol::IBLTSync).
+			setComm(GenSync::SyncComm::socket).
+			setBits(BITS).
+			setNumExpectedElements(EXP_ELEM_OTHER).
+			build();
+
+	GenSync GenSyncClient = GenSync::Builder().
+			setProtocol(GenSync::SyncProtocol::IBLTSync).
+			setComm(GenSync::SyncComm::socket).
+			setBits(BITS).
+			setNumExpectedElements(EXP_ELEM).
+			build();
+
+	//oneWay = false, prob = true, syncParamTest = true
+	CPPUNIT_ASSERT(!(_syncTest(GenSyncClient,GenSyncServer,false,true,true)));
+}

--- a/tests/unit/IBLTSyncTest.h
+++ b/tests/unit/IBLTSyncTest.h
@@ -15,7 +15,8 @@ class IBLTSyncTest : public CPPUNIT_NS::TestFixture {
         CPPUNIT_TEST(justSyncTest);
         CPPUNIT_TEST(testAddDelElem);
         CPPUNIT_TEST(testGetStrings);
-        //CPPUNIT_TEST(largeInputTest);
+		CPPUNIT_TEST(testIBLTParamMismatch);
+		//CPPUNIT_TEST(largeInputTest);
 
     CPPUNIT_TEST_SUITE_END();
 public:
@@ -25,16 +26,29 @@ public:
     void setUp() override;
     void tearDown() override;
 
-    // Test reconciliation
+	/**
+	 * Test reconciliation
+	 */
     void justSyncTest();
 
-    // Test adding and deleting elements
-    void testAddDelElem();
+	/**
+	 * Test adding and deleting elements
+	 */
+	void testAddDelElem();
 
-    // Test that printElem() and getName() return some nonempty string
+	/**
+ 	* Test that printElem() and getName() return some nonempty string
+ 	*/
     void testGetStrings();
 
-	// Test that IBLT Functions properly for very large inputs
+	/**
+ 	* Test that IBLT Sync reports failure properly with incompatible sync parameters (Different number of expected elements)
+ 	*/
+    void testIBLTParamMismatch();
+
+	/**
+ 	* Test that IBLT Functions properly for very large inputs
+ 	*/
 	//void largeInputTest();
 };
 

--- a/tests/unit/IBLTTest.h
+++ b/tests/unit/IBLTTest.h
@@ -22,7 +22,9 @@ public:
     void setUp();
     void tearDown();
 
-    // Tests every function in IBLT together, except for size
+	/**
+ 	* Tests every function in IBLT together, except for size
+ 	*/
     void testAll();
 };
 


### PR DESCRIPTION
> * If possible, please use javadoc notation /** */ to describe test cases; this way the IDE will pick them up as documentation.
> * in the description for _syncFailTest - don't you mean that no two _incompatible_ GenSync objects should sync successfully?  Is it possible to abstract out the forking part of the code into a private method for code reuse (e.g. in CommSocketTest::SocketSendAndReceiveTest)?
> * In "CommSocketTest.java", use `PORT` to denote a field in javadoc.
> * Why is the "large input test" for IBLT commented out?
> * Is the TextAuxilliar.h:_syncTest code similar in logic to what was origianlly?

1. Updated

2. Updated

3. Updated

4. I haven't implemented this yet but I'm planning to add this test case to all of the syncs

5. Yes, the test still fails and succeeds under the same conditions 

Also commented out one of the TryMe examples that was preventing compilation