### PR TITLE
add error check test for ibltSync

### DIFF
--- a/tests/TestAuxiliary.h
+++ b/tests/TestAuxiliary.h
@@ -1021,7 +1021,6 @@ inline bool longTermSync(GenSync &GenSyncClient,
 			client.insert(i);
 		}
 
-
 		pid_t pID = fork();
 
 		// Client Process
@@ -1110,7 +1109,6 @@ inline bool longTermSync(GenSync &GenSyncClient,
 			{
 				resServer.insert(dop);
 			}
-
 
 			if (!syncParamTest)
 			{

--- a/tests/sys/benchmark/BenchmarkTest.cpp
+++ b/tests/sys/benchmark/BenchmarkTest.cpp
@@ -219,20 +219,20 @@ void BenchmarkTest::IBLTSyncLongTerm()
 
 void BenchmarkTest::IBLTSyncErrBenchMark()
 {
-	const int testRuns = 40;														  // Number of times to sync
-	const int SIMILAR = 32;															  //Number of elements in common between the server and client
-	const int DIFS = 8;																  // Number of elements unique to the server AND number of elements unique to client (Sym Difs = DIFS *2)
-	const int failExpected = testRuns * (1 - pow(1 - exp(-N_HASH / N_HASHCHECK), 4)); //Amount of failures should be less than P[error] * number of runs
-	int failCount = 0;																  //Keeps track of how many synchronizations are reported as failures for comparison to theoretical value
+	const int testRuns = 40;															   // Number of times to sync
+	const int SIMILAR = 32;																   // Number of elements in common between the server and client
+	const int DIFS = 8;																	   // Number of elements unique to the server AND number of elements unique to client (Sym Difs = DIFS *2)
+	const int failExpected = testRuns * (1 - pow(1 - exp(-N_HASH / N_HASHCHECK), N_HASH)); // Amount of failures should be less than P[error] * number of runss,
+																						   // see https://arxiv.org/pdf/1101.2245.pdf for how this error being calculated.
+	int failCount = 0;																	   // Keeps track of how many synchronizations are reported as failures for comparison to theoretical value
 
-	//Vector containing by now only IBLTSync
+	// Vector containing by now only IBLTSync
 	vector<GenSync> IBLTSyncServer = twoWayProbCombos(2 * DIFS + SIMILAR);
 	vector<GenSync> IBLTSyncClient = twoWayProbCombos(2 * DIFS + SIMILAR);
 
-	//Itterate through each type of sync (CPISync, ProbCPISync, InterCPISync) exclude FullSync because it does not have a theoretical probability of failure
 	for (int ii = 0; ii < IBLTSyncClient.size() - 1; ii++)
 	{
-		//Test that less than (failExpected) tests fail in (testRuns) tests for sets
+		// Test that less than (failExpected) tests fail in (testRuns) tests for sets
 		for (int jj = 0; jj < testRuns; jj++)
 		{
 			bool success = benchmarkSync(IBLTSyncClient.at(ii), IBLTSyncServer.at(ii), SIMILAR, DIFS, DIFS, true, false);
@@ -241,7 +241,7 @@ void BenchmarkTest::IBLTSyncErrBenchMark()
 				failCount++;
 			}
 		}
-		//If more test failed than the calculated failExpected, then CPISync's error may not be properly bounded
+		//If more test failed than the calculated failExpected, then IBLTSync's error may not be properly bounded
 		CPPUNIT_ASSERT(failCount < failExpected);
 	}
 }

--- a/tests/sys/benchmark/BenchmarkTest.cpp
+++ b/tests/sys/benchmark/BenchmarkTest.cpp
@@ -203,7 +203,7 @@ void BenchmarkTest::IBLTSyncLongTerm()
 	const int difPerRound = 3;   // # of elems to be added to client during each round
 	const bool multiSet = false; // true iff it's testing on multiset
 	bool success = true;		 // true iff test succeeds in the end
-	bool details = true;		 // true iff to show inner progress during test
+	bool details = false;		 // true iff to show inner progress during test
 
 	// # ExpElems should be the total expected # of set after reconciliation, but not m_bar which are used for twoWayCombos funciton
 	vector<GenSync> IBLTSyncClient = twoWayProbCombos(difPerRound * testRounds + dif + similiar);
@@ -215,4 +215,33 @@ void BenchmarkTest::IBLTSyncLongTerm()
 	}
 
 	CPPUNIT_ASSERT(success);
+}
+
+void BenchmarkTest::IBLTSyncErrBenchMark()
+{
+	const int testRuns = 40;														  // Number of times to sync
+	const int SIMILAR = 32;															  //Number of elements in common between the server and client
+	const int DIFS = 8;																  // Number of elements unique to the server AND number of elements unique to client (Sym Difs = DIFS *2)
+	const int failExpected = testRuns * (1 - pow(1 - exp(-N_HASH / N_HASHCHECK), 4)); //Amount of failures should be less than P[error] * number of runs
+	int failCount = 0;																  //Keeps track of how many synchronizations are reported as failures for comparison to theoretical value
+
+	//Vector containing by now only IBLTSync
+	vector<GenSync> IBLTSyncServer = twoWayProbCombos(2 * DIFS + SIMILAR);
+	vector<GenSync> IBLTSyncClient = twoWayProbCombos(2 * DIFS + SIMILAR);
+
+	//Itterate through each type of sync (CPISync, ProbCPISync, InterCPISync) exclude FullSync because it does not have a theoretical probability of failure
+	for (int ii = 0; ii < IBLTSyncClient.size() - 1; ii++)
+	{
+		//Test that less than (failExpected) tests fail in (testRuns) tests for sets
+		for (int jj = 0; jj < testRuns; jj++)
+		{
+			bool success = benchmarkSync(IBLTSyncClient.at(ii), IBLTSyncServer.at(ii), SIMILAR, DIFS, DIFS, true, false);
+			if (!success)
+			{
+				failCount++;
+			}
+		}
+		//If more test failed than the calculated failExpected, then CPISync's error may not be properly bounded
+		CPPUNIT_ASSERT(failCount < failExpected);
+	}
 }

--- a/tests/sys/benchmark/BenchmarkTest.h
+++ b/tests/sys/benchmark/BenchmarkTest.h
@@ -26,9 +26,9 @@ class BenchmarkTest : public CPPUNIT_NS::TestFixture
 	CPPUNIT_TEST(CPISyncLongTerm);
 	CPPUNIT_TEST(IBLTSyncLongTerm);
 	CPPUNIT_TEST(CPISyncErrorBenchmark);
+	CPPUNIT_TEST(IBLTSyncErrBenchMark);
 	CPPUNIT_TEST(TimedSyncThreshold);
 	CPPUNIT_TEST(BitThresholdTest);
-	//CPPUNIT_TEST(IBLTSyncErrBenchMark);
 
 	CPPUNIT_TEST_SUITE_END();
 


### PR DESCRIPTION
* The expElem parameter should be the expected size of set after reconciliation and this what causing problem that IBLTSync fails with abnormally high probability.
* Error check tests added for IBLT Sync