### PR TITLE
Cuckoo filter insertion strategy changed

### DIFF
--- a/include/CPISync/Syncs/Cuckoo.h
+++ b/include/CPISync/Syncs/Cuckoo.h
@@ -258,14 +258,14 @@ private:
      * @return The entry index where the fngprt is inserted
      * or -1 if the bucket is full.
      */
-    inline size_t addToBucket(size_t bucketIdx, unsigned f);
+    inline long long addToBucket(size_t bucketIdx, unsigned f);
 
     /**
      * @param f The fingerprint to search for.
      * @param bucket The bucket in which to search.
-     * @return Index of the fingerprint in the bucket.
+     * @return Index of the fingerprint in the bucket or -1 if it is not there.
      */
-    inline size_t hasF(unsigned f, size_t bucket) const;
+    inline int hasF(unsigned f, size_t bucket) const;
 
     /**
      * Calculate the alternative bucket for the given bucket and the fingerprint.
@@ -287,28 +287,29 @@ private:
      * Calculate the partial hash of the item.
      * @param datum The item to calculate partial hash for.
      * TODO: for fngprtSize=7 (f=119), fitlerSize=5, bucketSize=4
-     * can finish in 0, 1, and can be kicked to 4 (from 0), instead of 1.
+     * can end up in 0, 1, and can be kicked to 4 (from 0), instead of 1.
      * _alternativeBucket(1, 119) == 0, _alternativeBucket(0, 119) == 4.
      * This introduces false negatives and Cuckoo Filter should not have any.
      */
     inline PartialHash _pHash(const DataObject& datum) const;
 
     /**
-     * Auxiliary structure to track relocations in insert procedure.
+     * Auxiliary structure to track the previous state of the filter
+     * during the insertion.
      */
-    struct Reloc {
-        size_t b; // bucket index
-        size_t c; // cell index
+    struct Slot {
+        size_t b;          // bucket index
+        size_t c;          // cell index
         unsigned int f;    // fingerprint to put there
     };
 
     /**
-     * Commit the changes to the cuckoo filter storage.
-     * To be used only when the relocation chain does not exceed maxKicks.
-     * @param relocStack The relocation chain.
+     * Restores filter to its state before the insertion when the
+     * insertion chain exceeds the predefined hard limit.
+     * @param originalSlots The values of the visited slots before they are
+     * modified.
      */
-    inline void _commit_relocation_chain(stack<Reloc>& relocStack);
-
+    inline void _restore_filter(stack<Slot>& originalSlots);
 
     // NESTED CLASSES
     class CuckooFilterError : public runtime_error {

--- a/src/Syncs/Cuckoo.cpp
+++ b/src/Syncs/Cuckoo.cpp
@@ -71,8 +71,7 @@ Cuckoo::Cuckoo(size_t capacity, float err) {
         // we are looking for a small f but a relatively high b. The
         // smaller b, the smaller f. But the smaller b, the higher
         // failed insertion probability.
-        size_t f = narrow_cast<size_t>(ceil(log2(1 / err) + log2(2 * b))); // Eq. 6 from the
-                                                  // paper
+        size_t f = narrow_cast<size_t>(ceil(log2(1 / err) + log2(2 * b))); // Eq. 6 from the paper
 
         // if the smaller b does not give us at least two less bits in
         // f keep the best b at the current value
@@ -118,11 +117,11 @@ vector<unsigned char> Cuckoo::getRawFilter() const {
     return filter.getRaw();
 }
 
-void Cuckoo::_commit_relocation_chain(stack<Reloc>& relocStack) {
-    while (!relocStack.empty()) {
-        Reloc r = relocStack.top();
-        relocStack.pop();
-        filter.setEntry(r.b, r.c, r.f);
+void Cuckoo::_restore_filter(stack<Slot>& originalSlots) {
+    while (!originalSlots.empty()) {
+        Slot s = originalSlots.top();
+        originalSlots.pop();
+        filter.setEntry(s.b, s.c, s.f);
     }
 }
 
@@ -144,30 +143,34 @@ bool Cuckoo::insert(const DataObject& datum) {
     // The fingerprint to put in that bucket
     auto f = p.f;
 
-    stack<Reloc> relocStack;
+    stack<Slot> originalSlots;
     for (size_t kick=0; kick<maxKicks; kick++) {
         // Choose the fingerprint from the bucket to relocate
         size_t victimIdx = narrow_cast<size_t>(_rand(0, bucketSize - 1));
         size_t victim = filter.getEntry(chosenBucket, victimIdx);
         size_t altBucket = _alternativeBucket(chosenBucket, victim);
 
-        Reloc r;
-        r.b = chosenBucket;
-        r.c = victimIdx;
-        r.f = f;
-        relocStack.push(r);
+        // Overwrite victim with the fingerprint being inserted. Later
+        // on, if insert fails, we will restore the filter.
+        filter.setEntry(chosenBucket, victimIdx, f);
 
         if (addToBucket(altBucket, victim) != -1) {
-            _commit_relocation_chain(relocStack);
             itemsCount++;
             return true;
         }
+
+        Slot s;
+        s.b = chosenBucket;
+        s.c = victimIdx;
+        s.f = victim;
+        originalSlots.push(s);
 
         f = victim;
         chosenBucket = altBucket;
     }
 
     // Relocation chain exceeded maxKicks
+    _restore_filter(originalSlots);
     return false;
 }
 
@@ -184,7 +187,7 @@ bool Cuckoo::erase(const DataObject& datum) {
 
     PartialHash p = _pHash(datum);
 
-    size_t idx = hasF(p.f, p.i1);
+    int idx = hasF(p.f, p.i1);
     if (idx != -1) {
         filter.setEntry(p.i1, idx, 0);
         itemsCount--;
@@ -234,7 +237,7 @@ ZZ Cuckoo::hash(const ZZ& e) const {
     return hash_impl(e, filterSize);
 }
 
-size_t Cuckoo::addToBucket(size_t bucketIdx, unsigned f) {
+long long Cuckoo::addToBucket(size_t bucketIdx, unsigned f) {
     for (size_t ii=0; ii<bucketSize; ii++)
         // Put the fingerprint in the first available entry
         if (filter.getEntry(bucketIdx, ii) == 0) {
@@ -245,7 +248,7 @@ size_t Cuckoo::addToBucket(size_t bucketIdx, unsigned f) {
     return -1;
 }
 
-size_t Cuckoo::hasF(unsigned f, size_t bucket) const {
+int Cuckoo::hasF(unsigned f, size_t bucket) const {
     for (size_t ii=0; ii < bucketSize; ii++)
         if (filter.getEntry(bucket, ii) == f)
             return ii;
@@ -265,6 +268,9 @@ Cuckoo::PartialHash Cuckoo::_pHash(const DataObject& datum) const {
     p.f = fingerprint(datum.to_ZZ());
     p.i1 = to_int(hash(datum.to_ZZ()));
     p.i2 = _alternativeBucket(p.i1, p.f);
+
+    if (p.i1 != _alternativeBucket(p.i2, p.f))
+        throw CuckooFilterError("This hash algorithm is not suitable for cuckoo hashing.");
 
     return p;
 }

--- a/tests/unit/CuckooTest.cpp
+++ b/tests/unit/CuckooTest.cpp
@@ -96,8 +96,8 @@ void CuckooTest::testConfigF3() {
 }
 
 void CuckooTest::testConfigF7() {
-    Cuckoo c = Cuckoo(7, 4, 5, 20);
-    auto inserted = _populate(c, 19, 1 << 12);
+    Cuckoo c = Cuckoo(9, 8, 32, 20);
+    auto inserted = _populate(c, 230, 1 << 12);
 
     // Because of item range >> f => for (almost) all f: f != item
     // don't expect any* failed inserts
@@ -108,6 +108,15 @@ void CuckooTest::testConfigF7() {
     // theory dictates no false negatives, under some
     // implementatitonal circumstances they do occur. The reason for
     // false negatives is explained in the docstring of Cuckoo::_pHash.
+    CPPUNIT_ASSERT_EQUAL(0LU, _lost_items(c, inserted));
+}
+
+void CuckooTest::testConfigF8() {
+    Cuckoo c = Cuckoo(8, 4, 12, 10);
+    auto inserted = _populate(c, 22, 64 * (1 << 8));
+
+    CPPUNIT_ASSERT_EQUAL(0LU, _failed_insert_count(inserted));
+
     CPPUNIT_ASSERT_EQUAL(0LU, _lost_items(c, inserted));
 }
 
@@ -147,9 +156,7 @@ void CuckooTest::testConfigF3B1() {
 
     CPPUNIT_ASSERT(_failed_insert_count(inserted) <= 2);
 
-    CPPUNIT_ASSERT(_lost_items(c, inserted) <= 2);
-    // Explained in testConfigF7
-    // CPPUNIT_ASSERT_EQUAL(0LU, _lost_items(c, inserted));
+    CPPUNIT_ASSERT_EQUAL(0LU, _lost_items(c, inserted));
 
 }
 
@@ -163,14 +170,12 @@ void CuckooTest::testConfigF14B1() {
 }
 
 void CuckooTest::testConfigF7B15() {
-    Cuckoo c = Cuckoo(7, 15, 10, 5);
-    auto inserted = _populate(c, 140, 1 << 16); // alpha 144/150 ~= 93%
+    Cuckoo c = Cuckoo(7, 15, 32, 5);
+    auto inserted = _populate(c, 446, 1 << 16); // alpha 144/150 ~= 93%
 
     CPPUNIT_ASSERT(_failed_insert_count(inserted) <= 2);
 
-    CPPUNIT_ASSERT(_lost_items(c, inserted) <= 2);
-    // Explained in testConfigF7
-    // CPPUNIT_ASSERT_EQUAL(0LU, _lost_items(c, inserted));
+    CPPUNIT_ASSERT_EQUAL(0LU, _lost_items(c, inserted));
 }
 
 void CuckooTest::testConfigF7B3() {

--- a/tests/unit/CuckooTest.h
+++ b/tests/unit/CuckooTest.h
@@ -83,6 +83,7 @@ public:
      */
     static void testConfigF3();
     static void testConfigF7();
+    static void testConfigF8();
     static void testConfigF13();
     static void testConfigF30();
     static void testConfigF3B1();


### PR DESCRIPTION
After reviewing the theory behind general cuckoo hashing, it turned
out that insert operation atomicity should better be achieved through
restore-when-fail than through commit-when-succeed. The latter
technique, that I have previously used, would require some graph
analysis to be totally correct.

Additionally, Cuckoo::_pHash function that handles cuckoo partial
hashing will now throw an exception when hash function (potentially
user-provided) does not work well for partial hashing. A hash function
that generates `bucket_1 == alternative_bucket(bucket_2, f)` for all f,
is now explicitly required.

Besides the above changes, I have also made few minor types modifications.