### PR TITLE
Remove probSync and syncParamTest parameter from syncTest

### DIFF
--- a/include/CPISync/Syncs/IBLTMultiset.h
+++ b/include/CPISync/Syncs/IBLTMultiset.h
@@ -20,7 +20,6 @@ public:
      * Constructs an IBLT object with size relative to expectedNumEntries.
      * @param expectedNumEntries The expected amount of entries to be placed into the IBLT
      * @param _valueSize The size of the values being added, in bits
-     * @param isMultiset Is the IBLT going to store multiset values, default is false
      */
     IBLTMultiset(size_t expectedNumEntries, size_t _valueSize);
 

--- a/tests/TestAuxiliary.h
+++ b/tests/TestAuxiliary.h
@@ -448,8 +448,6 @@ checkClientSucceeded(multiset<string> &resultantClient, multiset<string> &initia
  * @param GenSyncClient The GenSync object that is client in the sync.
  * @param GenSyncServer The GenSync object that is server in the sync.
  * @param oneWay true iff the sync will be one way (only server is reconciled)
- * @param probSync true iff the sync method being used is probabilistic (changes the conditions for success)
- * @param syncParamTest true if you would like to know if the sync believes it succeeded regardless of the actual state
  * of the sets (For parameter mismatch testing)
  * @param SIMILAR amount of elements common to both genSyncs
  * @param CLIENT_MINUS_SERVER amount of elements unique to client
@@ -458,10 +456,12 @@ checkClientSucceeded(multiset<string> &resultantClient, multiset<string> &initia
  * @return True if the recon appears to be successful and false otherwise
  * @return true if reconciliation succeeded, false otherwise
  */
-inline bool createForkForTest(GenSync& GenSyncClient, GenSync& GenSyncServer,bool oneWay, bool probSync,bool syncParamTest,
-                               const unsigned int SIMILAR,const unsigned int CLIENT_MINUS_SERVER,
-                               const unsigned int SERVER_MINUS_CLIENT, multiset<string> reconciled,
-                               bool setofSets){
+inline bool createForkForTest(GenSync &GenSyncClient, GenSync &GenSyncServer, bool oneWay,
+                              const unsigned int SIMILAR,
+                              const unsigned int CLIENT_MINUS_SERVER,
+                              const unsigned int SERVER_MINUS_CLIENT,
+                              multiset<string> reconciled,
+                              bool setofSets) {
 
     int child_state;
     int my_opt = 0;
@@ -887,15 +887,13 @@ inline void addElemsSetofSets(GenSync &GenSyncServer,
  * @param oneWay true iff the sync will be one way (only server is reconciled). One way syncs require that the looping be done
  * around the constructor of the GenSync Object and the port be changed each test because of how processes handle port closures.
  * This means that for oneWay syncs syncTest will only loop once internally and the function will have to be called again from the test
- * @param probSync true iff the sync method being used is probabilistic (changes the conditions for success)
- * @param syncParamTest true if you would like to know if the sync believes it succeeded regardless of the actual state
  * of the sets (For parameter mismatch testing)
  * @param Multiset true iff you would like to test syncing a multiset
  * @param largeSync true if you would like to test syncing a large number of elements
  * @return True if *every* recon test appears to be successful (and, if syncParamTest==true, reports that it is successful) and false otherwise.
  */
-inline bool syncTest(GenSync &GenSyncClient, GenSync &GenSyncServer, bool oneWay, bool probSync, bool syncParamTest,
-						bool Multiset,bool largeSync){
+inline bool syncTest(GenSync &GenSyncClient, GenSync &GenSyncServer, bool oneWay,
+                     bool Multiset, bool largeSync) {
 
 	//Seed test so that changing other tests does not cause failure in tests with a small probability of failure
 	//Don't seed oneWay tests because they loop on the outside of syncTest and you want different values for each run
@@ -916,7 +914,7 @@ inline bool syncTest(GenSync &GenSyncClient, GenSync &GenSyncServer, bool oneWay
 		// add elements to server, client and reconciled
 		auto objectsPtr = addElements(Multiset,SIMILAR,SERVER_MINUS_CLIENT,CLIENT_MINUS_SERVER,GenSyncServer,GenSyncClient,reconciled);
 		//Returns a boolean value for the success of the synchronization
-        success &= createForkForTest(GenSyncClient, GenSyncServer, oneWay, probSync, syncParamTest, SIMILAR,
+        success &= createForkForTest(GenSyncClient, GenSyncServer, oneWay, SIMILAR,
                                       CLIENT_MINUS_SERVER,SERVER_MINUS_CLIENT, reconciled,false);
 		//Remove all elements from GenSyncs and clear dynamically allocated memory for reuse
 		success &= GenSyncServer.clearData();

--- a/tests/sys/long/GenericSyncTests.cpp
+++ b/tests/sys/long/GenericSyncTests.cpp
@@ -98,8 +98,8 @@ void GenSyncTest::testAddRemoveSyncMethodAndComm() {
     CPPUNIT_ASSERT_EQUAL((CPISync*)(*genSync.getSyncAgt(0)).get(), toAdd.get());
 
     // syncing with the newly added commsocket and probcpisync should succeed
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = false, largeSync = false)
-	CPPUNIT_ASSERT(syncTest(genSync, genSyncOther, false, false, false, false, false));
+	//(oneWay = false, Multiset = false, largeSync = false)
+	CPPUNIT_ASSERT(syncTest(genSync, genSyncOther, false, false, false));
 
     // test deleting a communicant by index and by pointer
     genSync.delComm(cs);
@@ -137,8 +137,8 @@ void GenSyncTest::testCounters() {
 
     // get an upper bound of the time since the last sync to test against `res`
     auto before = std::chrono::high_resolution_clock::now();
-	//(oneWay = false, probSync = false)
-	CPPUNIT_ASSERT(syncTest(genSyncOther, genSync, false,false,false,false,false));
+	//(oneWay = false)
+	CPPUNIT_ASSERT(syncTest(genSyncOther, genSync, false, false, false));
 
     // check that Communicant counters == the respective GenSync counters
     CPPUNIT_ASSERT_EQUAL(cs->getXmitBytes(), genSync.getXmitBytes(0));
@@ -175,8 +175,8 @@ void GenSyncTest::testTwoWaySync() {
 	vector<GenSync> twoWayServer = twoWayCombos(mBar);
 	// sync every GenSync configuration with itself
 	for (unsigned int ii = 0; ii < twoWayClient.size(); ii++)
-		//(oneWay = false, probSync = false, syncParamTest = false, Multiset = false, largeSync = false)
-		CPPUNIT_ASSERT(syncTest(twoWayClient.at(ii), twoWayServer.at(ii), false, false, false, false, false));
+		//(oneWay = false, Multiset = false, largeSync = false)
+		CPPUNIT_ASSERT(syncTest(twoWayClient.at(ii), twoWayServer.at(ii), false, false, false));
 }
 
 void GenSyncTest::testOneWaySync() {
@@ -201,8 +201,8 @@ void GenSyncTest::testOneWaySync() {
 				setPort(port - 1 - ii).
 				build();
 
-		//(oneWay = true, probSync = false, syncParamTest = false, Multiset = false, largeSync = false)
-		CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, true, false, false, false, false));
+		//(oneWay = true, Multiset = false, largeSync = false)
+		CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, true, false, false));
 	}
 }
 
@@ -212,8 +212,8 @@ void GenSyncTest::testTwoWayProbSync() {
 
 	// sync every GenSync configuration with itself
 	for (unsigned int ii = 0; ii < twoWayProbClient.size(); ii++) {
-		//(oneWay = false, probSync = true, syncParamTest = false, Multiset = false, largeSync = false)
-		CPPUNIT_ASSERT(syncTest(twoWayProbClient.at(ii), twoWayProbServer.at(ii), false, true, false, false, false));
+		//(oneWay = false, Multiset = false, largeSync = false)
+		CPPUNIT_ASSERT(syncTest(twoWayProbClient.at(ii), twoWayProbServer.at(ii), false, false, false));
 	}
 }
 
@@ -236,7 +236,7 @@ void GenSyncTest::testOneWayProbSync() {
 				setPort(port + 1 + ii).
 				build();
 
-		//(oneWay = true, probSync = true, syncParamTest = false, Multiset = false, largeSync = false)
-		CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, true, true, false, false, false));
+		//(oneWay = true, Multiset = false, largeSync = false)
+		CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, true, false, false));
 	}
 }

--- a/tests/unit/CPISyncTest.cpp
+++ b/tests/unit/CPISyncTest.cpp
@@ -73,8 +73,8 @@ void CPISyncTest::CPISyncSetReconcileTest() {
 				setErr(err).
 				build();
 
-		//(oneWay = false, probSync = false, syncParamTest = false, Multiset = false, largeSync = false)
-		CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false, false, false));
+		//(oneWay = false, Multiset = false, largeSync = false)
+		CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false));
 }
 
 
@@ -97,8 +97,8 @@ void CPISyncTest::CPISyncMultisetReconcileTest() {
 			setHashes(true).
 			build();
 
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = true, largeSync = false)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer,false, false,false,true,false));
+	//(oneWay = false, Multiset = true, largeSync = false)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer,false, true, false));
 }
 
 void CPISyncTest::CPISyncLargeSetReconcileTest() {
@@ -118,8 +118,8 @@ void CPISyncTest::CPISyncLargeSetReconcileTest() {
 			setErr(err).
 			build();
 
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = false, largeSync = true)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false, false, true));
+	//(oneWay = false, Multiset = false, largeSync = true)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, true));
 }
 
 void CPISyncTest::ProbCPISyncSetReconcileTest() {
@@ -139,8 +139,8 @@ void CPISyncTest::ProbCPISyncSetReconcileTest() {
 			setErr(err).
 			build();
 
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = false, largeSync = false)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false, false, false));
+	//(oneWay = false, Multiset = false, largeSync = false)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer,false, false, false));
 }
 
 void CPISyncTest::ProbCPISyncMultisetReconcileTest() {
@@ -162,8 +162,8 @@ void CPISyncTest::ProbCPISyncMultisetReconcileTest() {
 			setHashes(true).
 			build();
 
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = true, largeSync = false)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false, true, false));
+	//(oneWay = false, Multiset = true, largeSync = false)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, true, false));
 }
 
 void CPISyncTest::ProbCPISyncLargeSetReconcileTest(){
@@ -183,8 +183,8 @@ void CPISyncTest::ProbCPISyncLargeSetReconcileTest(){
 			setErr(err).
 			build();
 
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = false, largeSync = true)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false,false,false,true));
+	//(oneWay = false, Multiset = false, largeSync = true)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, true));
 }
 
 //InterCPISync Test Cases
@@ -240,8 +240,8 @@ void CPISyncTest::InterCPISyncSetReconcileTest() {
 			setNumPartitions(numParts).
 			build();
 
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = false, largeSync = false)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false,false, false, false));
+	//(oneWay = false, Multiset = false, largeSync = false)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false));
 }
 
 void CPISyncTest::InterCPISyncMultisetReconcileTest() {
@@ -268,8 +268,8 @@ void CPISyncTest::InterCPISyncMultisetReconcileTest() {
 			setHashes(true).
 			build();
 
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = true, largeSync = false)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false, true, false));
+	//(oneWay = false, Multiset = true, largeSync = false)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, true, false));
 }
 
 
@@ -297,6 +297,6 @@ void CPISyncTest::InterCPISyncLargeSetReconcileTest() {
 			setHashes(true).
 			build();
 
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = false, largeSync = true)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false, false, true));
+	//(oneWay = false, Multiset = false, largeSync = true)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, true));
 }

--- a/tests/unit/CuckooSyncTest.cpp
+++ b/tests/unit/CuckooSyncTest.cpp
@@ -58,5 +58,5 @@ void CuckooSyncTest::setReconcileTest() {
     // before it reaches syncTest helper function.
     ZZ_p::init(randZZ());
 
-    CPPUNIT_ASSERT(syncTest(client, server, false, false, false, false, false));
+    CPPUNIT_ASSERT(syncTest(client, server, false, false, false));
 }

--- a/tests/unit/FullSyncTest.cpp
+++ b/tests/unit/FullSyncTest.cpp
@@ -36,8 +36,8 @@ void FullSyncTest::FullSyncSetReconcileTest() {
 			setProtocol(GenSync::SyncProtocol::FullSync).
 			setComm(GenSync::SyncComm::socket).
 			build();
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = false, largeSync = false)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false, false, false));
+	//(oneWay = false, Multiset = false, largeSync = false)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false));
 }
 
  void FullSyncTest::FullSyncMultisetReconcileTest(){
@@ -51,8 +51,8 @@ void FullSyncTest::FullSyncSetReconcileTest() {
 			 setComm(GenSync::SyncComm::socket).
 			 build();
 
-	 //(oneWay = false, probSync = false, syncParamTest = false, Multiset = true, largeSync = false)
-	 CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false, true, false));
+	 //(oneWay = false, Multiset = true, largeSync = false)
+	 CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, true, false));
 }
 
 void FullSyncTest::FullSyncLargeSetReconcileTest() {
@@ -67,8 +67,8 @@ void FullSyncTest::FullSyncLargeSetReconcileTest() {
 			setComm(GenSync::SyncComm::socket).
 			build();
 
-	//(oneWay = false, probSync = false, syncParamTest = false, Multiset = false, largeSync = true)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false, false, true));
+	//(oneWay = false, Multiset = false, largeSync = true)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, true));
 }
 
 

--- a/tests/unit/IBLTSyncTest.cpp
+++ b/tests/unit/IBLTSyncTest.cpp
@@ -38,8 +38,8 @@ void IBLTSyncTest::IBLTSyncSetReconcileTest() {
 			setExpNumElems(numExpElem).
 			build();
 
-	//(oneWay = false, probSync = true, syncParamTest = false, Multiset = false, largeSync = false)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, true, false, false, false));
+	//(oneWay = false, Multiset = false, largeSync = false)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, false));
 }
 
 void IBLTSyncTest::IBLTSyncMultisetReconcileTest() {
@@ -59,8 +59,8 @@ void IBLTSyncTest::IBLTSyncMultisetReconcileTest() {
 			setExpNumElems(numExpElem).
 			build();
 
-	//(oneWay = false, probSync = true, syncParamTest = false, Multiset = true, largeSync = false)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, true, false, true, false));
+	//(oneWay = false, Multiset = true, largeSync = false)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, true, false));
 }
 
 void IBLTSyncTest::IBLTSyncLargeSetReconcileTest() {
@@ -80,8 +80,8 @@ void IBLTSyncTest::IBLTSyncLargeSetReconcileTest() {
 			setExpNumElems(largeNumExpElems).
 			build();
 
-	//(oneWay = false, probSync = true, syncParamTest = false, Multiset = false, largeSync = true)
-	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, true,false,false,true));
+	//(oneWay = false, Multiset = false, largeSync = true)
+	CPPUNIT_ASSERT(syncTest(GenSyncClient, GenSyncServer, false, false, true));
 }
 
 void IBLTSyncTest::testAddDelElem() {
@@ -135,6 +135,6 @@ void IBLTSyncTest::testIBLTParamMismatch(){
 			setExpNumElems(numExpElem).
 			build();
 
-	//(oneWay = false, probSync = true, syncParamTest = true, Multiset = false, largeSync = false)
-	CPPUNIT_ASSERT(!(syncTest(GenSyncClient, GenSyncServer, false, true, true, false, false)));
+	//(oneWay = false, Multiset = false, largeSync = false)
+	CPPUNIT_ASSERT(!(syncTest(GenSyncClient, GenSyncServer, false, false, false)));
 }


### PR DESCRIPTION
Fixes [Issue#70](https://github.com/trachten/cpisync/issues/70) and [Issue#72](https://github.com/trachten/cpisync/issues/72)

- Remove probSync and syncParamTest parameter from syncTest
 - remove unused isMultiset  entry from docs