### PR TITLE
Communicant refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set(HEADERS
         ${AUX_DIR_INC}/Logger.h
         ${AUX_DIR_INC}/SyncMethod.h
         ${AUX_DIR_INC}/UID.h
+        ${AUX_DIR_INC}/Serializable.h
 
         ${DATA_DIR_INC}/DataFileC.h
         ${DATA_DIR_INC}/DataMemC.h

--- a/include/CPISync/Aux/Auxiliary.h
+++ b/include/CPISync/Aux/Auxiliary.h
@@ -71,7 +71,8 @@ inline vector<byte> StrToVec(const string& data) {
     vector<byte> result; // where we will be build the result to be returned
 
     const char *data_c_str = data.c_str();
-    result.reserve((int) data.length()); result.reserve((int) data.length()); for (int ii = 0; ii < (int) data.length(); ii++)
+    result.reserve((int) data.length());
+    for (int ii = 0; ii < (int) data.length(); ii++)
         result.push_back(static_cast<byte>(data_c_str[ii]));
 
     return result;
@@ -120,7 +121,7 @@ inline ZZ strToZZ(string str)
 }
 
 /**
- * Decode an encoded large numebr from strToZZ function into an  ascii string
+ * Decode an encoded large number from strToZZ function into an  ascii string
  * @param num the ZZ to be converted
  * @require input ZZ number must be generated from strToZZ function 
  * @return an ascii string
@@ -150,6 +151,69 @@ inline string zzToString(ZZ num)
         out += str[ii];
     return out;
 }
+
+/**
+ * convert bytes from buffer to a number
+ * @tparam T - numerics of types int, long, unsigned long
+ * @param buffer pointer to byte representation of number
+ * @return the deserialized number
+ */
+template<typename T>
+inline T fromBytes(const byte* buffer) {
+    ZZ num = ZZFromBytes(buffer, sizeof(T));
+    T res = conv<T>(num);
+    return res;
+}
+
+/**
+ * convert bytes from buffer to a ZZ
+ * @param buf the buffer which has byte representation of ZZ
+ * @param bytesRead the number of bytes used for this ZZ,
+ *        this is used by the caller function to increase the buffer pointer
+ * @return the deserialized ZZ num
+ */
+inline ZZ fromBytesZZ(const byte* buf, long &bytesRead) {
+    ZZ res{0};
+    long numBytes = fromBytes<long>(buf);
+    res = ZZFromBytes(buf+sizeof(long), numBytes);
+    // the no of bytes that were used to represent this ZZ
+    bytesRead = numBytes + sizeof(long);
+    return res;
+}
+
+/**
+ * convert number types to byte vector
+ * @tparam T - of types int, long, unsigned long
+ * @param num - the number to convert to bytes
+ * @return vector<byte>, a byte representation of obj
+ */
+
+template<typename T>
+inline vector<byte> toBytes(T num) {
+    size_t numBytes = sizeof(T);
+    vector<byte> res(numBytes);
+    BytesFromZZ(res.data(), to_ZZ(num), numBytes);
+    return res;
+}
+
+/**
+ * convert a ZZ to byte vector
+ * @param num - the number to convert to bytes
+ * @return vector<byte>, a byte representation of obj
+ *
+ */
+template<>
+inline vector<byte> toBytes(ZZ num) {
+    long numBytes = NumBytes(num);
+    if (numBytes==0) numBytes = 1; // special case to send 0 value
+    vector<byte> res(numBytes);
+    BytesFromZZ(res.data(), num, numBytes);
+    vector<byte> numInBytes = toBytes(numBytes);
+    res.insert(res.begin(), numInBytes.begin(), numInBytes.end());
+    return res;
+}
+
+
 
 
 /**

--- a/include/CPISync/Aux/Serializable.h
+++ b/include/CPISync/Aux/Serializable.h
@@ -1,0 +1,30 @@
+//
+// Created by shubham on 9/11/20.
+//
+
+#ifndef CPISYNC_SERIALIZABLE_H
+#define CPISYNC_SERIALIZABLE_H
+
+#include <vector>
+
+using namespace std;
+
+class Serializable {
+public:
+
+    virtual ~Serializable() = default;
+
+    /**
+     * create a byte representation of data structure, to send over socket
+     * @return vector<byte> representation of members
+     */
+    virtual vector<byte> toByteVector() const = 0;
+
+    /**
+     * recreate internal data structure from byte representation received over socket
+     * @param buffer vector<byte>
+     */
+    virtual void fromByteVector(vector<byte> buffer) = 0;
+};
+
+#endif //CPISYNC_SERIALIZABLE_H

--- a/include/CPISync/Communicants/Communicant.h
+++ b/include/CPISync/Communicants/Communicant.h
@@ -117,7 +117,7 @@ public:
     /**
     * Primitive for sending data over an existing connection.  All other sending methods
     * eventually call this.
-    * @param str The string to be transmitted.
+    * @param toString The char array to be transmitted.
     * @param numBytes The number of characters in the string.  If set to 0, then this length is computed.
     * @require listen or connect must have been called to establish a connection.
     * @modify updates xferBytes buffer with the amount of data actually transmitted.
@@ -327,12 +327,21 @@ public:
     byte commRecv_byte();
 
     /**
+     * receives an IBLT
+     * constructs their IBLT from the string representation that is received
+     * @return
+     */
+    IBLT commRecv_IBLT_des(Nullable<size_t> size=NOT_SET<size_t>(), Nullable<size_t> eltSize=NOT_SET<size_t>());
+
+    /**
      * Receives an IBLT.
      * @param size The size of the IBLT to be received.  Must be >0 or NOT_SET.
      * @param eltSize The size of values of the IBLTs to be received.  Must be >0 or NOT_SET.
      * If parameters aren't set, the IBLT will be received successfully iff commSend(IBLT, false) was used to send the IBLT
      */
     IBLT commRecv_IBLT(Nullable<size_t> size=NOT_SET<size_t>(), Nullable<size_t> eltSize=NOT_SET<size_t>());
+
+    IBLTMultiset commRecv_IBLTMultiset_des(Nullable<size_t> size, Nullable<size_t> eltSize);
 
     /**
      * Receives an IBLTMultiset.

--- a/include/CPISync/Communicants/Communicant.h
+++ b/include/CPISync/Communicants/Communicant.h
@@ -243,13 +243,6 @@ public:
     void commSend(const IBLT &iblt, bool sync = false);
 
     /**
-     * Sends an IBLTMultiset.
-     * @param iblt The IBLTMultiset to send.
-     * @param sync Should be true iff EstablishModSend/Recv called and/or the receiver knows the IBLT's size and eltSize
-     */
-    void commSend(const IBLTMultiset &iblt, bool sync = false);
-
-    /**
      * Sends Cuckoo filter.
      * @param The Cuckoo filter to send.
      */
@@ -327,13 +320,6 @@ public:
     byte commRecv_byte();
 
     /**
-     * receives an IBLT
-     * constructs their IBLT from the string representation that is received
-     * @return
-     */
-    IBLT commRecv_IBLT_des(Nullable<size_t> size=NOT_SET<size_t>(), Nullable<size_t> eltSize=NOT_SET<size_t>());
-
-    /**
      * Receives an IBLT.
      * @param size The size of the IBLT to be received.  Must be >0 or NOT_SET.
      * @param eltSize The size of values of the IBLTs to be received.  Must be >0 or NOT_SET.
@@ -341,7 +327,6 @@ public:
      */
     IBLT commRecv_IBLT(Nullable<size_t> size=NOT_SET<size_t>(), Nullable<size_t> eltSize=NOT_SET<size_t>());
 
-    IBLTMultiset commRecv_IBLTMultiset_des(Nullable<size_t> size, Nullable<size_t> eltSize);
 
     /**
      * Receives an IBLTMultiset.
@@ -399,21 +384,10 @@ protected:
      */
     void commSend(const IBLT::HashTableEntry &hte, size_t eltSize);
 
-//    /**
-//     * Sends an IBLTMultiset::HashTableEntry
-//     * @param hte The HashTableEntry to send
-//     */
-//    void commSend(const IBLTMultiset::HashTableEntry& hte, size_t eltSize);
-
     /**
      * Receives an IBLT::HashTableEntry
      */
     IBLT::HashTableEntry commRecv_HashTableEntry(size_t eltSize);
-
-    /**
-     * Receives an IBLTMultiset::HashTableEntry
-     */
-    IBLTMultiset::HashTableEntry commRecv_HashTableEntry_Multiset(size_t eltSize);
 
     /**
      * Adds <numBytes> bytes to the transmitted byte logs

--- a/include/CPISync/Communicants/Communicant.h
+++ b/include/CPISync/Communicants/Communicant.h
@@ -379,17 +379,6 @@ protected:
 
     // METHODS
     /**
-     * Sends an IBLT::HashTableEntry
-     * @param hte The HashTableEntry to send
-     */
-    void commSend(const IBLT::HashTableEntry &hte, size_t eltSize);
-
-    /**
-     * Receives an IBLT::HashTableEntry
-     */
-    IBLT::HashTableEntry commRecv_HashTableEntry(size_t eltSize);
-
-    /**
      * Adds <numBytes> bytes to the transmitted byte logs
      * @param numBytes the number of bytes to add to the logs
      */

--- a/include/CPISync/Communicants/Communicant.h
+++ b/include/CPISync/Communicants/Communicant.h
@@ -390,11 +390,11 @@ protected:
      */
     void commSend(const IBLT::HashTableEntry &hte, size_t eltSize);
 
-    /**
-     * Sends an IBLTMultiset::HashTableEntry
-     * @param hte The HashTableEntry to send
-     */
-    void commSend(const IBLTMultiset::HashTableEntry& hte, size_t eltSize);
+//    /**
+//     * Sends an IBLTMultiset::HashTableEntry
+//     * @param hte The HashTableEntry to send
+//     */
+//    void commSend(const IBLTMultiset::HashTableEntry& hte, size_t eltSize);
 
     /**
      * Receives an IBLT::HashTableEntry

--- a/include/CPISync/Syncs/Cuckoo.h
+++ b/include/CPISync/Syncs/Cuckoo.h
@@ -20,6 +20,7 @@
 #include <CPISync/Data/DataObject.h>
 #include <CPISync/Aux/Auxiliary.h>
 #include <CPISync/Syncs/Compact2DBitArray.h>
+#include <CPISync/Aux/Serializable.h>
 
 using std::vector;
 using std::shared_ptr;
@@ -27,7 +28,7 @@ using std::string;
 using std::runtime_error;
 using namespace NTL;
 
-class Cuckoo {
+class Cuckoo : public Serializable {
 public:
 
     /**
@@ -153,6 +154,21 @@ public:
      * Seed the underlying cuckoo filter PRNG
      */
     static void seedPRNG(unsigned int seed);
+
+    /**
+     * serialize cuckoo filter to a byte vector,
+     * which can be deserialized by `fromByteVector`
+     * @return vector<byte> representation of cuckoo filter
+     */
+    vector<byte> toByteVector() const;
+
+    /**
+     * deserialize byte vector and construct cuckoo filter,
+     * complements function `toByteVector`
+     * @require buffer size can be at most UNSIGNED_LONG_MAX
+     * @param buffer vector<byte> representation of cuckoo filter
+     */
+    void fromByteVector(vector<byte> buffer);
 
     /**
      * Maximum length of the cuckoo evictions chain

--- a/include/CPISync/Syncs/IBLT.h
+++ b/include/CPISync/Syncs/IBLT.h
@@ -114,13 +114,13 @@ public:
      * Convert IBLT to a readable string
      * @return string
     */
-    string toString() const;
+    virtual string toString() const;
 
     /**
      * fill the hashTable with a string generated from IBLT.toString() function
      * @param inStr a readable ascii string generted from IBLT.toString() function
     */
-    void reBuild(string &inStr);
+    virtual void reBuild(string &inStr);
     /**
      * Subtracts two IBLTs.
      * -= is destructive and assigns the resulting iblt to the lvalue, whereas - isn't. -= is more efficient than -
@@ -129,6 +129,8 @@ public:
      */
     IBLT operator-(const IBLT& other) const;
     IBLT& operator-=(const IBLT& other);
+
+//    bool operator==(const IBLT& other);
 
     /**
      * @return the number of cells in the IBLT. Not necessarily equal to the expected number of entries
@@ -139,6 +141,10 @@ public:
      * @return the size of a value stored in the IBLT.
      */
     size_t eltSize() const;
+//
+//    char* serialize();
+//
+//    static IBLT deserialize(char * serializedIBLT);
 
     vector<hash_t> hashes; /* vector for all hashes of sets */
 
@@ -185,7 +191,7 @@ protected:
         ZZ valueSum;
 
         // Returns whether the entry contains just one insertion or deletion
-        bool isPure() const;
+        virtual bool isPure() const;
 
         // Returns whether the entry is empty
         bool empty() const;

--- a/include/CPISync/Syncs/IBLT.h
+++ b/include/CPISync/Syncs/IBLT.h
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <CPISync/Aux/Auxiliary.h>
 #include <CPISync/Data/DataObject.h>
+#include <CPISync/Aux/Serializable.h>
 
 using std::vector;
 using std::hash;
@@ -40,7 +41,7 @@ typedef unsigned long int hash_t;
  * Goodrich, Michael T., and Michael Mitzenmacher. "Invertible bloom lookup tables." 
  * arXiv preprint arXiv:1101.2245 (2011).
  */
-class IBLT {
+class IBLT : public Serializable{
 public:
     // Communicant needs to access the internal representation of an IBLT to send and receive it
     friend class Communicant;
@@ -109,6 +110,19 @@ public:
      * @param expnChldSet expected number of elements in the target set
     */
     void erase(multiset<shared_ptr<DataObject>> tarSet, size_t elemSize, size_t expnChldSet);
+
+    /**
+     * convert IBLTMultiset to bytes to be sent over socket
+     * @return vector<byte> to send over socket
+     */
+    vector<byte> toByteVector() const override;
+
+    /**
+     * @require hashtable size is already instantiated
+     * @require element size is set
+     * @param data vector<byte>
+     */
+    void fromByteVector(vector<byte> data) override;
 
     /**
      * Convert IBLT to a readable string

--- a/include/CPISync/Syncs/IBLT.h
+++ b/include/CPISync/Syncs/IBLT.h
@@ -62,7 +62,7 @@ public:
      * @param value The value to be added
      * @require The key must be distinct in the IBLT
      */
-    void insert(ZZ key, ZZ value);
+    virtual void insert(ZZ key, ZZ value);
     
     /**
      * Erases a key-value pair from the IBLT.
@@ -70,7 +70,7 @@ public:
      * @param key The key to be removed
      * @param value The value to be removed
      */
-    void erase(ZZ key, ZZ value);
+    virtual void erase(ZZ key, ZZ value);
     
     /**
      * Produces the value s.t. (key, value) is in the IBLT.

--- a/include/CPISync/Syncs/IBLT.h
+++ b/include/CPISync/Syncs/IBLT.h
@@ -144,7 +144,6 @@ public:
     IBLT operator-(const IBLT& other) const;
     IBLT& operator-=(const IBLT& other);
 
-//    bool operator==(const IBLT& other);
 
     /**
      * @return the number of cells in the IBLT. Not necessarily equal to the expected number of entries
@@ -155,10 +154,6 @@ public:
      * @return the size of a value stored in the IBLT.
      */
     size_t eltSize() const;
-//
-//    char* serialize();
-//
-//    static IBLT deserialize(char * serializedIBLT);
 
     vector<hash_t> hashes; /* vector for all hashes of sets */
 

--- a/include/CPISync/Syncs/IBLTMultiset.h
+++ b/include/CPISync/Syncs/IBLTMultiset.h
@@ -33,7 +33,7 @@ public:
      * @param value The value to be added
      * @require The key must be distinct in the IBLT
      */
-    void insert(ZZ key, ZZ value);
+    void insert(ZZ key, ZZ value) override;
 
     /**
      * Erases a key-value pair from the IBLT.
@@ -41,7 +41,7 @@ public:
      * @param key The key to be removed
      * @param value The value to be removed
      */
-    void erase(ZZ key, ZZ value);
+    void erase(ZZ key, ZZ value) override;
 
     /**
      * Produces the value s.t. (key, value) is in the IBLT.
@@ -100,32 +100,38 @@ private:
      * @param key The key to insert or delete
      * @param value The value to insert or delete
      */
-    void _insertModular(long plusOrMinus, ZZ key, ZZ value);
+    void _insertModular(long plusOrMinus, const ZZ &key, const ZZ &value);
 
-    class HashTableEntry
-    {
+//    class HashTableEntry {
+//    public:
+//        // Net insertions and deletions that mapped to this cell
+//        long count;
+//
+//        // The bitwise xor-sum of all keys mapped to this cell
+//        ZZ keySum;
+//
+//        // The bitwise xor-sum of all keySum checksums at each allocation
+//        hash_t keyCheck;
+//
+//        // The bitwise xor-sum of all values mapped to this cell
+//        ZZ valueSum;
+//
+//////         Returns whether the entry contains just one insertion or deletion
+////        bool isPure() const;
+//
+//        // Returns whether the entry contains just insertions or deletions of only one key-value pair
+//        bool isPure() const;
+//
+//        // Returns whether the entry is empty
+//        bool empty() const;
+//    };
+
+    class HashTableEntry : public IBLT::HashTableEntry {
     public:
-        // Net insertions and deletions that mapped to this cell
-        long count;
-
-        // The bitwise xor-sum of all keys mapped to this cell
-        ZZ keySum;
-
-        // The bitwise xor-sum of all keySum checksums at each allocation
-        hash_t keyCheck;
-
-        // The bitwise xor-sum of all values mapped to this cell
-        ZZ valueSum;
-
-        // Returns whether the entry contains just one insertion or deletion
         bool isPure() const;
-
-        // Returns whether the entry contains just insertions or deletions of only one key-value pair
-        bool isMultiPure() const ;
-
-        // Returns whether the entry is empty
-        bool empty() const;
     };
+
+
 
     // vector of all entries
     vector<HashTableEntry> hashTable;

--- a/include/CPISync/Syncs/IBLTMultiset.h
+++ b/include/CPISync/Syncs/IBLTMultiset.h
@@ -87,8 +87,6 @@ public:
 
     vector<hash_t> hashes; /* vector for all hashes of sets */
 
-    string toString() const override;
-
     /**
      * convert IBLTMultiset to bytes to be sent over socket
      * @return vector<byte> to send over socket
@@ -101,8 +99,6 @@ public:
      * @param data vector<byte>
      */
     void fromByteVector(vector<byte> data);
-
-    void reBuild(string &inStr) override;
 
 private:
     /**

--- a/include/CPISync/Syncs/IBLTMultiset.h
+++ b/include/CPISync/Syncs/IBLTMultiset.h
@@ -66,11 +66,11 @@ public:
      */
     bool listEntries(vector<pair<ZZ, ZZ>>& positive, vector<pair<ZZ, ZZ>>& negative);
 
-    /**
-     * Convert IBLT to a readable string
-     * @return string
-    */
-    string toString() const;
+//    /**
+//     * Convert IBLT to a readable string
+//     * @return string
+//    */
+//    string toString() const;
 
     /**
      * Subtracts two IBLTs.
@@ -92,6 +92,10 @@ public:
     size_t eltSize() const;
 
     vector<hash_t> hashes; /* vector for all hashes of sets */
+
+    string toString() const override;
+
+    void reBuild(string &inStr) override;
 
 private:
     /**
@@ -128,9 +132,8 @@ private:
 
     class HashTableEntry : public IBLT::HashTableEntry {
     public:
-        bool isPure() const;
+        bool isPure() const override;
     };
-
 
 
     // vector of all entries

--- a/include/CPISync/Syncs/IBLTMultiset.h
+++ b/include/CPISync/Syncs/IBLTMultiset.h
@@ -95,6 +95,19 @@ public:
 
     string toString() const override;
 
+    /**
+     * convert IBLTMultiset to bytes to be sent over socket
+     * @return vector<byte> to send over socket
+     */
+    vector<byte> toByteVector() const override;
+
+    /**
+     * @require hashtable size is already instantiated
+     * @require element size is set
+     * @param data vector<byte>
+     */
+    void fromByteVector(vector<byte> data);
+
     void reBuild(string &inStr) override;
 
 private:

--- a/include/CPISync/Syncs/IBLTMultiset.h
+++ b/include/CPISync/Syncs/IBLTMultiset.h
@@ -66,12 +66,6 @@ public:
      */
     bool listEntries(vector<pair<ZZ, ZZ>>& positive, vector<pair<ZZ, ZZ>>& negative);
 
-//    /**
-//     * Convert IBLT to a readable string
-//     * @return string
-//    */
-//    string toString() const;
-
     /**
      * Subtracts two IBLTs.
      * -= is destructive and assigns the resulting iblt to the lvalue, whereas - isn't. -= is more efficient than -
@@ -119,35 +113,10 @@ private:
      */
     void _insertModular(long plusOrMinus, const ZZ &key, const ZZ &value);
 
-//    class HashTableEntry {
-//    public:
-//        // Net insertions and deletions that mapped to this cell
-//        long count;
-//
-//        // The bitwise xor-sum of all keys mapped to this cell
-//        ZZ keySum;
-//
-//        // The bitwise xor-sum of all keySum checksums at each allocation
-//        hash_t keyCheck;
-//
-//        // The bitwise xor-sum of all values mapped to this cell
-//        ZZ valueSum;
-//
-//////         Returns whether the entry contains just one insertion or deletion
-////        bool isPure() const;
-//
-//        // Returns whether the entry contains just insertions or deletions of only one key-value pair
-//        bool isPure() const;
-//
-//        // Returns whether the entry is empty
-//        bool empty() const;
-//    };
-
     class HashTableEntry : public IBLT::HashTableEntry {
     public:
         bool isPure() const override;
     };
-
 
     // vector of all entries
     vector<HashTableEntry> hashTable;

--- a/src/Communicants/Communicant.cpp
+++ b/src/Communicants/Communicant.cpp
@@ -522,6 +522,17 @@ ZZ Communicant::commRecv_ZZ(const int size) {
     return result;
 }
 
+IBLT Communicant::commRecv_IBLT_des(Nullable<size_t> size, Nullable<size_t> eltSize) {
+    IBLT theirs;
+    theirs.valueSize = eltSize;
+    theirs.hashTable.resize(size);
+
+    string serialIBLT = commRecv_string();
+
+    theirs.reBuild(serialIBLT);
+    return theirs;
+}
+
 IBLT Communicant::commRecv_IBLT(Nullable<size_t> size, Nullable<size_t> eltSize) {
     size_t numSize;
     size_t numEltSize;
@@ -541,6 +552,17 @@ IBLT Communicant::commRecv_IBLT(Nullable<size_t> size, Nullable<size_t> eltSize)
         theirs.hashTable.push_back(commRecv_HashTableEntry(numEltSize));
     }
 
+    return theirs;
+}
+
+IBLTMultiset Communicant::commRecv_IBLTMultiset_des(Nullable<size_t> size, Nullable<size_t> eltSize) {
+    IBLTMultiset theirs;
+    theirs.valueSize = eltSize;
+    theirs.hashTable.resize(size);
+
+    string serialIBLT = commRecv_string();
+
+    theirs.reBuild(serialIBLT);
     return theirs;
 }
 

--- a/src/Communicants/Communicant.cpp
+++ b/src/Communicants/Communicant.cpp
@@ -310,12 +310,12 @@ void Communicant::commSend(const IBLT::HashTableEntry& hte, size_t eltSize) {
     commSend(hte.valueSum, (int) eltSize);
 }
 
-void Communicant::commSend(const IBLTMultiset::HashTableEntry& hte, size_t eltSize) {
-    commSend(hte.count);
-    commSend(toStr<size_t>(hte.keyCheck));
-    commSend(hte.keySum); // not guaranteed to be the same size as all other hash-table-entry key-sums
-    commSend(hte.valueSum, (int) eltSize);
-}
+//void Communicant::commSend(const IBLTMultiset::HashTableEntry& hte, size_t eltSize) {
+//    commSend(hte.count);
+//    commSend(toStr<size_t>(hte.keyCheck));
+//    commSend(hte.keySum); // not guaranteed to be the same size as all other hash-table-entry key-sums
+//    commSend(hte.valueSum, (int) eltSize);
+//}
 
 void Communicant::commSend(const ZZ& num, Nullable<size_t> size) {
     Logger::gLog(Logger::COMM, "... attempting to send: ZZ " + toStr(num));

--- a/src/Syncs/IBLT.cpp
+++ b/src/Syncs/IBLT.cpp
@@ -207,22 +207,40 @@ size_t IBLT::eltSize() const {
     return valueSize;
 }
 
-//char* IBLT::serialize() {
-//    string rep = toString();
-//    // memory leak
-//    char* res = new char[rep.length() + 1];
-//    strcpy(res, rep.c_str());
-//
-//    //or
-//
-//    vector<char> cstr(rep.c_str(), rep.c_str()+rep.length() + 1);
-//    return res;
-//}
-//
-//IBLT IBLT::deserialize(char * serializedIBLT) {
-//    IBLT res;
-//    return res;
-//}
+vector<byte> IBLT::toByteVector() const {
+    vector<byte> res;
+    for (auto entry: hashTable) {
+        vector<byte> byteRep = toBytes<long>(entry.count);
+        res.insert(res.end(), byteRep.begin(), byteRep.end());
+        byteRep = toBytes<hash_t>(entry.keyCheck);
+        res.insert(res.end(), byteRep.begin(), byteRep.end());
+        byteRep = toBytes(entry.keySum);
+        res.insert(res.end(), byteRep.begin(), byteRep.end());
+        byteRep = toBytes(entry.valueSum);
+        res.insert(res.end(), byteRep.begin(), byteRep.end());
+    }
+    cout << "serialize complete, hashtable size: " << hashTable.size() << endl;
+    return res;
+}
+
+void IBLT::fromByteVector(vector<byte> data) {
+    vector<byte> res;
+    byte *buf = data.data();
+    for (long index = 0; index < hashTable.size(); index++) {
+        hashTable[index].count = fromBytes<long>(buf);
+        buf += sizeof(long);
+        hashTable[index].keyCheck = fromBytes<hash_t>(buf);
+        buf += sizeof(hash_t);
+        long bytesRead;
+        hashTable[index].keySum = fromBytesZZ(buf, bytesRead);
+        buf += bytesRead;
+        hashTable[index].valueSum = fromBytesZZ(buf, bytesRead);
+        buf += bytesRead;
+    }
+    Logger::gLog(Logger::METHOD_DETAILS, "IBLT fromByteVector complete, "
+                               "read entries: " + toStr(hashTable.size()));
+}
+
 
 string IBLT::toString() const
 {

--- a/src/Syncs/IBLT.cpp
+++ b/src/Syncs/IBLT.cpp
@@ -194,10 +194,6 @@ IBLT IBLT::operator-(const IBLT& other) const {
     return result;
 }
 
-//bool IBLT::operator==(const IBLT& other) {
-//    return false;
-//}
-
 
 size_t IBLT::size() const {
     return hashTable.size();

--- a/src/Syncs/IBLT.cpp
+++ b/src/Syncs/IBLT.cpp
@@ -215,7 +215,16 @@ vector<byte> IBLT::toByteVector() const {
         byteRep = toBytes(entry.valueSum);
         res.insert(res.end(), byteRep.begin(), byteRep.end());
     }
-    cout << "serialize complete, hashtable size: " << hashTable.size() << endl;
+
+    // if IBLTSetOfSet
+    if (hashes.size() > 0 ) {
+        vector<byte> byteRep = toBytes((long)hashes.size());
+        res.insert(res.end(), byteRep.begin(), byteRep.end());
+        for (const auto &hash : hashes) {
+            byteRep = toBytes(hash);
+            res.insert(res.end(), byteRep.begin(), byteRep.end());
+        }
+    }
     return res;
 }
 
@@ -232,6 +241,17 @@ void IBLT::fromByteVector(vector<byte> data) {
         buf += bytesRead;
         hashTable[index].valueSum = fromBytesZZ(buf, bytesRead);
         buf += bytesRead;
+    }
+
+    // if IBLTSetOfSet
+    if (hashes.size() > 0 && buf != data.data() + data.size()) {
+        long hashNum = fromBytes<long>(buf);
+        buf += sizeof(hashNum);
+        hashes.resize(hashNum);
+        for (int ii = 0; ii < hashNum; ii++) {
+            hashes[ii] = fromBytes<hash_t>(buf);
+            buf += sizeof(hash_t);
+        }
     }
     Logger::gLog(Logger::METHOD_DETAILS, "IBLT fromByteVector complete, "
                                "read entries: " + toStr(hashTable.size()));

--- a/src/Syncs/IBLT.cpp
+++ b/src/Syncs/IBLT.cpp
@@ -194,6 +194,11 @@ IBLT IBLT::operator-(const IBLT& other) const {
     return result;
 }
 
+//bool IBLT::operator==(const IBLT& other) {
+//    return false;
+//}
+
+
 size_t IBLT::size() const {
     return hashTable.size();
 }
@@ -201,6 +206,23 @@ size_t IBLT::size() const {
 size_t IBLT::eltSize() const {
     return valueSize;
 }
+
+//char* IBLT::serialize() {
+//    string rep = toString();
+//    // memory leak
+//    char* res = new char[rep.length() + 1];
+//    strcpy(res, rep.c_str());
+//
+//    //or
+//
+//    vector<char> cstr(rep.c_str(), rep.c_str()+rep.length() + 1);
+//    return res;
+//}
+//
+//IBLT IBLT::deserialize(char * serializedIBLT) {
+//    IBLT res;
+//    return res;
+//}
 
 string IBLT::toString() const
 {
@@ -221,16 +243,22 @@ void IBLT::reBuild(string &inStr)
 {
     vector<string> entries = split(inStr, '\n');
     int index = 0;
-    for (auto entry : entries)
-    {
-        vector<string> infos = split(entry, ',');
-        HashTableEntry curEntry;
-        curEntry.count = strTo<long>(infos[0]);
-        curEntry.keyCheck = strTo<hash_t>(infos[1]);
-        curEntry.keySum = strTo<ZZ>(infos[2]);
-        curEntry.valueSum = strTo<ZZ>(infos[3]);
-        this->hashTable[index] = curEntry;
-        index++;
+    try {
+        for (auto entry : entries)
+        {
+
+            vector<string> infos = split(entry, ',');
+            HashTableEntry curEntry;
+            curEntry.count = strTo<long>(infos[0]);
+            curEntry.keyCheck = strTo<hash_t>(infos[1]);
+            curEntry.keySum = strTo<ZZ>(infos[2]);
+            curEntry.valueSum = strTo<ZZ>(infos[3]);
+            this->hashTable[index] = curEntry;
+            index++;
+        }
+    } catch (exception &err) {
+        Logger::gLog(Logger::TEST, "Exception in IBLT::reBuild");
+        Logger::gLog(Logger::TEST, err.what());
     }
 }
 

--- a/src/Syncs/IBLT.cpp
+++ b/src/Syncs/IBLT.cpp
@@ -244,7 +244,7 @@ void IBLT::fromByteVector(vector<byte> data) {
     }
 
     // if IBLTSetOfSet
-    if (hashes.size() > 0 && buf != data.data() + data.size()) {
+    if (buf != data.data() + data.size()) {
         long hashNum = fromBytes<long>(buf);
         buf += sizeof(hashNum);
         hashes.resize(hashNum);

--- a/src/Syncs/IBLTMultiset.cpp
+++ b/src/Syncs/IBLTMultiset.cpp
@@ -238,36 +238,3 @@ void IBLTMultiset::fromByteVector(vector<byte> data) {
     Logger::gLog(Logger::METHOD_DETAILS, "IBLTMultiset fromByteVectorComplete");
 }
 
-string IBLTMultiset::toString() const {
-    string outStr="";
-    for (auto entry : hashTable)
-    {
-        outStr += toStr<long>(entry.count) + ","
-                  + toStr<hash_t>(entry.keyCheck) + ","
-                  + toStr<ZZ>(entry.keySum) + ","
-                  + toStr<ZZ>(entry.valueSum)
-                  + "\n";
-    }
-    outStr.pop_back();
-    return outStr;
-}
-
-void IBLTMultiset::reBuild(string &inStr) {
-    vector<string> entries = split(inStr, '\n');
-    int index = 0;
-    try {
-        for (auto entry : entries) {
-            vector<string> infos = split(entry, ',');
-            HashTableEntry curEntry;
-            curEntry.count = strTo<long>(infos[0]);
-            curEntry.keyCheck = strTo<hash_t>(infos[1]);
-            curEntry.keySum = strTo<ZZ>(infos[2]);
-            curEntry.valueSum = strTo<ZZ>(infos[3]);
-            this->hashTable[index] = curEntry;
-            index++;
-        }
-    } catch (exception &err) {
-        Logger::gLog(Logger::TEST, "Exception in IBLTMultiset::reBuild");
-        Logger::gLog(Logger::TEST, err.what());
-    }
-}

--- a/src/Syncs/IBLTMultiset.cpp
+++ b/src/Syncs/IBLTMultiset.cpp
@@ -19,7 +19,7 @@ IBLTMultiset::IBLTMultiset(size_t expectedNumEntries, size_t _valueSize)
 }
 
 // perform modular subtraction
-hash_t _subModHash(hash_t x, hash_t y ) {
+hash_t subModHash(hash_t x, hash_t y ) {
     long res = (long(x%LARGE_PRIME) - long(y%LARGE_PRIME)) % LARGE_PRIME;
     // must return positive modulus
     // C++ by default does not give positive modulus
@@ -30,7 +30,7 @@ hash_t _subModHash(hash_t x, hash_t y ) {
 }
 
 // perform modular addition
-hash_t _addModHash(hash_t x, hash_t y ) {
+hash_t addModHash(hash_t x, hash_t y ) {
     long res = (long(x%LARGE_PRIME) + long(y%LARGE_PRIME)) % LARGE_PRIME;
     // must return positive modulus
     // C++ by default does not give positive modulus
@@ -40,7 +40,7 @@ hash_t _addModHash(hash_t x, hash_t y ) {
     return res;
 }
 
-void IBLTMultiset::_insertModular(long plusOrMinus, ZZ key, ZZ value) {
+void IBLTMultiset::_insertModular(long plusOrMinus, const ZZ &key, const ZZ& value) {
     long bucketsPerHash = hashTable.size() / N_HASH;
 
     if(sizeof(value) != valueSize)
@@ -57,9 +57,9 @@ void IBLTMultiset::_insertModular(long plusOrMinus, ZZ key, ZZ value) {
         entry.count += plusOrMinus;
         entry.keySum += plusOrMinus*key;
         if (plusOrMinus == 1) {
-            entry.keyCheck = _addModHash(entry.keyCheck, modHashCheck);
+            entry.keyCheck = addModHash(entry.keyCheck, modHashCheck);
         } else if (plusOrMinus == -1) {
-            entry.keyCheck = _subModHash(entry.keyCheck, modHashCheck);
+            entry.keyCheck = subModHash(entry.keyCheck, modHashCheck);
         }
 
         if (entry.empty()) {
@@ -92,10 +92,11 @@ bool IBLTMultiset::get(ZZ key, ZZ& result){
             // result empty, return true.
             return true;
         }
-        else if (entry.isPure()) {
-            result = entry.valueSum / entry.count;
-            return true;
-        } else if(entry.isMultiPure()) {
+//        else if (entry.isPure()) {
+//            result = entry.valueSum / entry.count;
+//            return true;
+//        }
+        else if(entry.isPure()) {
             result = entry.valueSum / entry.count;
             return true;
         }
@@ -106,22 +107,23 @@ bool IBLTMultiset::get(ZZ key, ZZ& result){
     do {
         nErased = 0;
         for (IBLTMultiset::HashTableEntry &entry : this->hashTable) {
+//            if (entry.isPure()) {
+//                if (entry.count == 1 && entry.keySum == key) {
+//                    result = entry.valueSum;
+//                    return true;
+//                } else if (entry.count == -1 && entry.keySum == -key) {
+//                    result = -entry.valueSum;
+//                    return true;
+//                }
+//
+//                if (entry.count == 1)
+//                    this->_insertModular(-entry.count, entry.keySum, entry.valueSum);
+//                else
+//                    this->_insertModular(-entry.count, -entry.keySum, -entry.valueSum);
+//
+//                nErased++;
+//            } else if (entry.isMultiPure()) {
             if (entry.isPure()) {
-                if (entry.count == 1 && entry.keySum == key) {
-                    result = entry.valueSum;
-                    return true;
-                } else if (entry.count == -1 && entry.keySum == -key) {
-                    result = -entry.valueSum;
-                    return true;
-                }
-
-                if (entry.count == 1)
-                    this->_insertModular(-entry.count, entry.keySum, entry.valueSum);
-                else
-                    this->_insertModular(-entry.count, -entry.keySum, -entry.valueSum);
-
-                nErased++;
-            } else if (entry.isMultiPure()) {
                 if ( entry.keySum/entry.count == key) {
                     result = entry.valueSum/entry.count;
                     return true;
@@ -136,24 +138,24 @@ bool IBLTMultiset::get(ZZ key, ZZ& result){
     return false;
 }
 
-bool IBLTMultiset::HashTableEntry::isPure() const
-{
-    if ((count == 1 || count == -1) && keySum!=0) {
-        long plusOrMinus = conv<long>(keySum / abs(keySum));
-        hash_t check = _hashK(keySum*plusOrMinus, N_HASHCHECK);
-        hash_t modHash;
+//bool IBLTMultiset::HashTableEntry::isPure() const
+//{
+//    if ((count == 1 || count == -1) && keySum!=0) {
+//        long plusOrMinus = conv<long>(keySum / abs(keySum));
+//        hash_t check = _hashK(keySum*plusOrMinus, N_HASHCHECK);
+//        hash_t modHash;
+//
+//        if (plusOrMinus == 1)
+//            modHash = addModHash(0, check);
+//        else
+//            modHash = subModHash(0, check);
+//
+//        return (keyCheck == modHash);
+//    }
+//    return false;
+//}
 
-        if (plusOrMinus == 1)
-            modHash = _addModHash(0, check);
-        else
-            modHash = _subModHash(0, check);
-
-        return (keyCheck == modHash);
-    }
-    return false;
-}
-
-bool IBLTMultiset::HashTableEntry::isMultiPure() const {
+bool IBLTMultiset::HashTableEntry::isPure() const {
     if (count != 0 && keySum!=0) {
         long absCount = abs(count);
         long plusOrMinus = conv<long>(keySum / abs(keySum));
@@ -162,9 +164,9 @@ bool IBLTMultiset::HashTableEntry::isMultiPure() const {
         int ii = 0;
         while (ii < absCount) {
             if(plusOrMinus == 1)
-                check = _addModHash(check, singleCountHash);
+                check = addModHash(check, singleCountHash);
             else
-                check = _subModHash(check, singleCountHash);
+                check = subModHash(check, singleCountHash);
 
             ii++;
         }
@@ -179,22 +181,23 @@ bool IBLTMultiset::listEntries(vector<pair<ZZ, ZZ>> &positive, vector<pair<ZZ, Z
         nErased = 0;
         for(IBLTMultiset::HashTableEntry& entry : this->hashTable) {
 
+//            if (entry.isPure()) {
+//                if (entry.count == 1) {
+//                    positive.emplace_back(std::make_pair(entry.keySum, entry.valueSum));
+//                    this->_insertModular(-entry.count, entry.keySum, entry.valueSum);
+//                }
+//                else {
+//                    negative.emplace_back(std::make_pair(-entry.keySum, -entry.valueSum));
+//                    this->_insertModular(-entry.count, -entry.keySum, -entry.valueSum);
+//                }
+//
+//                ++nErased;
+//            }
+//            else if (entry.isMultiPure()) {
             if (entry.isPure()) {
-                if (entry.count == 1) {
-                    positive.emplace_back(std::make_pair(entry.keySum, entry.valueSum));
-                    this->_insertModular(-entry.count, entry.keySum, entry.valueSum);
-                }
-                else {
-                    negative.emplace_back(std::make_pair(-entry.keySum, -entry.valueSum));
-                    this->_insertModular(-entry.count, -entry.keySum, -entry.valueSum);
-                }
-
-                ++nErased;
-            }
-            else if (entry.isMultiPure()) {
-                if (entry.count > 1) {
+                if (entry.count >= 1) {
                     positive.emplace_back(std::make_pair(entry.keySum / entry.count, entry.valueSum / entry.count));
-                } else if (entry.count < -1) {
+                } else if (entry.count <= -1) {
                     negative.emplace_back(std::make_pair(entry.keySum / entry.count, entry.valueSum / entry.count));
                 } else {
                     Logger::error_and_quit("Unreachable state. Entry with count zero in IBLT.");
@@ -230,7 +233,7 @@ IBLTMultiset &IBLTMultiset::operator-=(const IBLTMultiset &other) {
 
         e1.count -= e2.count;
         e1.keySum -= e2.keySum;
-        e1.keyCheck = _subModHash(e1.keyCheck, e2.keyCheck);
+        e1.keyCheck = subModHash(e1.keyCheck, e2.keyCheck);
 
         if (e1.empty())
             e1.valueSum.kill();
@@ -270,7 +273,7 @@ string IBLTMultiset::toString() const
     return outStr;
 }
 
-bool IBLTMultiset::HashTableEntry::empty() const
-{
-    return (count == 0 && IsZero(keySum) && keyCheck == 0);
-}
+//bool IBLTMultiset::HashTableEntry::empty() const
+//{
+//    return (count == 0 && IsZero(keySum) && keyCheck == 0);
+//}

--- a/src/Syncs/IBLTMultiset.cpp
+++ b/src/Syncs/IBLTMultiset.cpp
@@ -258,26 +258,37 @@ size_t IBLTMultiset::eltSize() const {
     return valueSize;
 }
 
-//string IBLTMultiset::toString() const
-//{
-//    string outStr="";
-//    for (auto entry : hashTable)
-//    {
-//        outStr += toStr<long>(entry.count) + ","
-//                  + toStr<hash_t>(entry.keyCheck) + ","
-//                  + toStr<ZZ>(entry.keySum) + ","
-//                  + toStr<ZZ>(entry.valueSum)
-//                  + "\n";
-//    }
-//    outStr.pop_back();
-//    return outStr;
-//}
+vector<byte> IBLTMultiset::toByteVector() const {
+    vector<byte> res;
+    for (auto entry: hashTable) {
+        vector<byte> byteRep = toBytes(entry.count);
+        res.insert(res.end(), byteRep.begin(), byteRep.end());
+        byteRep = toBytes(entry.keyCheck);
+        res.insert(res.end(), byteRep.begin(), byteRep.end());
+        byteRep = toBytes(entry.keySum);
+        res.insert(res.end(), byteRep.begin(), byteRep.end());
+        byteRep = toBytes(entry.valueSum);
+        res.insert(res.end(), byteRep.begin(), byteRep.end());
+    }
+    return res;
+}
 
-//bool IBLTMultiset::HashTableEntry::empty() const
-//{
-//    return (count == 0 && IsZero(keySum) && keyCheck == 0);
-//}
-
+void IBLTMultiset::fromByteVector(vector<byte> data) {
+    vector<byte> res;
+    byte *buf = data.data();
+    for (long index = 0; index < hashTable.size(); index++) {
+        hashTable[index].count = fromBytes<long>(buf);
+        buf += sizeof(long);
+        hashTable[index].keyCheck = fromBytes<hash_t>(buf);
+        buf += sizeof(long);
+        long bytesRead;
+        hashTable[index].keySum = fromBytesZZ(buf, bytesRead);
+        buf += bytesRead;
+        hashTable[index].valueSum = fromBytesZZ(buf, bytesRead);
+        buf += bytesRead;
+    }
+    Logger::gLog(Logger::METHOD_DETAILS, "IBLTMultiset fromByteVectorComplete");
+}
 
 string IBLTMultiset::toString() const {
     string outStr="";

--- a/src/Syncs/IBLTMultiset.cpp
+++ b/src/Syncs/IBLTMultiset.cpp
@@ -258,8 +258,28 @@ size_t IBLTMultiset::eltSize() const {
     return valueSize;
 }
 
-string IBLTMultiset::toString() const
-{
+//string IBLTMultiset::toString() const
+//{
+//    string outStr="";
+//    for (auto entry : hashTable)
+//    {
+//        outStr += toStr<long>(entry.count) + ","
+//                  + toStr<hash_t>(entry.keyCheck) + ","
+//                  + toStr<ZZ>(entry.keySum) + ","
+//                  + toStr<ZZ>(entry.valueSum)
+//                  + "\n";
+//    }
+//    outStr.pop_back();
+//    return outStr;
+//}
+
+//bool IBLTMultiset::HashTableEntry::empty() const
+//{
+//    return (count == 0 && IsZero(keySum) && keyCheck == 0);
+//}
+
+
+string IBLTMultiset::toString() const {
     string outStr="";
     for (auto entry : hashTable)
     {
@@ -273,7 +293,22 @@ string IBLTMultiset::toString() const
     return outStr;
 }
 
-//bool IBLTMultiset::HashTableEntry::empty() const
-//{
-//    return (count == 0 && IsZero(keySum) && keyCheck == 0);
-//}
+void IBLTMultiset::reBuild(string &inStr) {
+    vector<string> entries = split(inStr, '\n');
+    int index = 0;
+    try {
+        for (auto entry : entries) {
+            vector<string> infos = split(entry, ',');
+            HashTableEntry curEntry;
+            curEntry.count = strTo<long>(infos[0]);
+            curEntry.keyCheck = strTo<hash_t>(infos[1]);
+            curEntry.keySum = strTo<ZZ>(infos[2]);
+            curEntry.valueSum = strTo<ZZ>(infos[3]);
+            this->hashTable[index] = curEntry;
+            index++;
+        }
+    } catch (exception &err) {
+        Logger::gLog(Logger::TEST, "Exception in IBLTMultiset::reBuild");
+        Logger::gLog(Logger::TEST, err.what());
+    }
+}

--- a/src/Syncs/IBLTMultiset.cpp
+++ b/src/Syncs/IBLTMultiset.cpp
@@ -91,12 +91,7 @@ bool IBLTMultiset::get(ZZ key, ZZ& result){
             // Definitely not in table. Leave
             // result empty, return true.
             return true;
-        }
-//        else if (entry.isPure()) {
-//            result = entry.valueSum / entry.count;
-//            return true;
-//        }
-        else if(entry.isPure()) {
+        } else if(entry.isPure()) {
             result = entry.valueSum / entry.count;
             return true;
         }
@@ -107,22 +102,6 @@ bool IBLTMultiset::get(ZZ key, ZZ& result){
     do {
         nErased = 0;
         for (IBLTMultiset::HashTableEntry &entry : this->hashTable) {
-//            if (entry.isPure()) {
-//                if (entry.count == 1 && entry.keySum == key) {
-//                    result = entry.valueSum;
-//                    return true;
-//                } else if (entry.count == -1 && entry.keySum == -key) {
-//                    result = -entry.valueSum;
-//                    return true;
-//                }
-//
-//                if (entry.count == 1)
-//                    this->_insertModular(-entry.count, entry.keySum, entry.valueSum);
-//                else
-//                    this->_insertModular(-entry.count, -entry.keySum, -entry.valueSum);
-//
-//                nErased++;
-//            } else if (entry.isMultiPure()) {
             if (entry.isPure()) {
                 if ( entry.keySum/entry.count == key) {
                     result = entry.valueSum/entry.count;
@@ -137,23 +116,6 @@ bool IBLTMultiset::get(ZZ key, ZZ& result){
 
     return false;
 }
-
-//bool IBLTMultiset::HashTableEntry::isPure() const
-//{
-//    if ((count == 1 || count == -1) && keySum!=0) {
-//        long plusOrMinus = conv<long>(keySum / abs(keySum));
-//        hash_t check = _hashK(keySum*plusOrMinus, N_HASHCHECK);
-//        hash_t modHash;
-//
-//        if (plusOrMinus == 1)
-//            modHash = addModHash(0, check);
-//        else
-//            modHash = subModHash(0, check);
-//
-//        return (keyCheck == modHash);
-//    }
-//    return false;
-//}
 
 bool IBLTMultiset::HashTableEntry::isPure() const {
     if (count != 0 && keySum!=0) {
@@ -180,20 +142,6 @@ bool IBLTMultiset::listEntries(vector<pair<ZZ, ZZ>> &positive, vector<pair<ZZ, Z
     do {
         nErased = 0;
         for(IBLTMultiset::HashTableEntry& entry : this->hashTable) {
-
-//            if (entry.isPure()) {
-//                if (entry.count == 1) {
-//                    positive.emplace_back(std::make_pair(entry.keySum, entry.valueSum));
-//                    this->_insertModular(-entry.count, entry.keySum, entry.valueSum);
-//                }
-//                else {
-//                    negative.emplace_back(std::make_pair(-entry.keySum, -entry.valueSum));
-//                    this->_insertModular(-entry.count, -entry.keySum, -entry.valueSum);
-//                }
-//
-//                ++nErased;
-//            }
-//            else if (entry.isMultiPure()) {
             if (entry.isPure()) {
                 if (entry.count >= 1) {
                     positive.emplace_back(std::make_pair(entry.keySum / entry.count, entry.valueSum / entry.count));

--- a/src/Syncs/IBLTSync.cpp
+++ b/src/Syncs/IBLTSync.cpp
@@ -40,8 +40,6 @@ bool IBLTSync::SyncClient(const shared_ptr<Communicant>& commSync, list<shared_p
             return false;
         }
 
-//        vector<unsigned char> myIBLTBytes = myIBLT.toByteVector();
-//        commSync->commSend(ustring(myIBLTBytes.data(), myIBLTBytes.size()));
         commSync->commSend(myIBLT, true);
         mySyncStats.timerEnd(SyncStats::COMM_TIME);
 

--- a/src/Syncs/IBLTSync.cpp
+++ b/src/Syncs/IBLTSync.cpp
@@ -39,7 +39,9 @@ bool IBLTSync::SyncClient(const shared_ptr<Communicant>& commSync, list<shared_p
             mySyncStats.increment(SyncStats::RECV,commSync->getRecvBytes());
             return false;
         }
-        commSync->commSend(myIBLT, true);
+
+//        commSync->commSend(myIBLT, true);
+        commSync->commSend(myIBLT.toString());
         mySyncStats.timerEnd(SyncStats::COMM_TIME);
 
 
@@ -97,7 +99,9 @@ bool IBLTSync::SyncServer(const shared_ptr<Communicant>& commSync, list<shared_p
         }
 
         // verified that our size and eltSize == theirs
-        IBLT theirs = commSync->commRecv_IBLT(myIBLT.size(), myIBLT.eltSize());
+//        IBLT theirs = commSync->commRecv_IBLT(myIBLT.size(), myIBLT.eltSize());
+        IBLT theirs = commSync->commRecv_IBLT_des(myIBLT.size(), myIBLT.eltSize());
+
         mySyncStats.timerEnd(SyncStats::COMM_TIME);
 
 

--- a/src/Syncs/IBLTSync.cpp
+++ b/src/Syncs/IBLTSync.cpp
@@ -40,8 +40,9 @@ bool IBLTSync::SyncClient(const shared_ptr<Communicant>& commSync, list<shared_p
             return false;
         }
 
-//        commSync->commSend(myIBLT, true);
-        commSync->commSend(myIBLT.toString());
+//        vector<unsigned char> myIBLTBytes = myIBLT.toByteVector();
+//        commSync->commSend(ustring(myIBLTBytes.data(), myIBLTBytes.size()));
+        commSync->commSend(myIBLT, true);
         mySyncStats.timerEnd(SyncStats::COMM_TIME);
 
 
@@ -99,8 +100,7 @@ bool IBLTSync::SyncServer(const shared_ptr<Communicant>& commSync, list<shared_p
         }
 
         // verified that our size and eltSize == theirs
-//        IBLT theirs = commSync->commRecv_IBLT(myIBLT.size(), myIBLT.eltSize());
-        IBLT theirs = commSync->commRecv_IBLT_des(myIBLT.size(), myIBLT.eltSize());
+        IBLT theirs = commSync->commRecv_IBLT(myIBLT.size(), myIBLT.eltSize());
 
         mySyncStats.timerEnd(SyncStats::COMM_TIME);
 

--- a/src/Syncs/IBLTSync_Multiset.cpp
+++ b/src/Syncs/IBLTSync_Multiset.cpp
@@ -34,7 +34,8 @@ bool IBLTSync_Multiset::SyncClient(const shared_ptr<Communicant>& commSync, list
             mySyncStats.increment(SyncStats::RECV,commSync->getRecvBytes());
             return false;
         }
-        commSync->commSend(myIBLT, true);
+//        commSync->commSend(myIBLT, true);
+        commSync->commSend(myIBLT.toString());
         mySyncStats.timerEnd(SyncStats::COMM_TIME);
 
 
@@ -93,7 +94,9 @@ bool IBLTSync_Multiset::SyncServer(const shared_ptr<Communicant>& commSync, list
         }
 
         // verified that our size and eltSize == theirs
-        IBLTMultiset theirs = commSync->commRecv_IBLTMultiset(myIBLT.size(), myIBLT.eltSize());
+//        IBLTMultiset theirs = commSync->commRecv_IBLTMultiset(myIBLT.size(), myIBLT.eltSize());
+        IBLTMultiset theirs = commSync->commRecv_IBLTMultiset_des(myIBLT.size(),
+                                                                  myIBLT.eltSize());
 
         mySyncStats.timerEnd(SyncStats::COMM_TIME);
 

--- a/src/Syncs/IBLTSync_Multiset.cpp
+++ b/src/Syncs/IBLTSync_Multiset.cpp
@@ -34,8 +34,7 @@ bool IBLTSync_Multiset::SyncClient(const shared_ptr<Communicant>& commSync, list
             mySyncStats.increment(SyncStats::RECV,commSync->getRecvBytes());
             return false;
         }
-//        commSync->commSend(myIBLT, true);
-        commSync->commSend(myIBLT.toString());
+        commSync->commSend(myIBLT, true);
         mySyncStats.timerEnd(SyncStats::COMM_TIME);
 
 
@@ -94,8 +93,7 @@ bool IBLTSync_Multiset::SyncServer(const shared_ptr<Communicant>& commSync, list
         }
 
         // verified that our size and eltSize == theirs
-//        IBLTMultiset theirs = commSync->commRecv_IBLTMultiset(myIBLT.size(), myIBLT.eltSize());
-        IBLTMultiset theirs = commSync->commRecv_IBLTMultiset_des(myIBLT.size(),
+        IBLTMultiset theirs = commSync->commRecv_IBLTMultiset(myIBLT.size(),
                                                                   myIBLT.eltSize());
 
         mySyncStats.timerEnd(SyncStats::COMM_TIME);


### PR DESCRIPTION
Addresses [Issue#68](https://github.com/trachten/cpisync/issues/68)

I have created an abstract class `Serializable`, that exposes two methods `vector<byte> toByteVector()` and `void fromByteVector(vector<byte> buffer)`.

I have changed the impementations of following non-interactive syncs / data structures to use this interface:
1. CuckooSync
2. IBLTSync
3. IBLTMultisetSync
4. IBLTSetsOfSets

I also streamlined (cleaned up) a lot of the `IBLTMultiset` implementation
