### PR TITLE
Integrating clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: LLVM
+IndentWidth: 4


### PR DESCRIPTION
Clang-format is a cross-editor auto-indentation plug-in

The idea is to declare the indentation rules in .clang-format file and
then to use standard editor mechanisms to indent the code using the
exact same indentation rules in all the editors.

Clang-format is already supported in some editors:
- CLion https://www.jetbrains.com/help/clion/clangformat-as-alternative-formatter.html
- VSCode https://code.visualstudio.com/docs/cpp/cpp-ide
- Emacs/Vim via ccls (https://github.com/MaskRay/ccls)